### PR TITLE
put zsh completions in custom folder

### DIFF
--- a/docs/completion.md
+++ b/docs/completion.md
@@ -4,7 +4,7 @@ If you are using Oh My ZSH you need to put the generated completion into the
 plugins folder.
 
 ```
-mkdir -p ~/.oh-my-zsh/plugins/awscnfm && awscnfm completion zsh > ~/.oh-my-zsh/plugins/awscnfm/_awscnfm
+mkdir -p ~/.oh-my-zsh/custom/plugins/awscnfm && awscnfm completion zsh > ~/.oh-my-zsh/custom/plugins/awscnfm/_awscnfm
 ```
 
 Then add `awscnfm` to the list of plugins that should be loaded when sourcing


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

This is so you do not mix your custom completions with the bundled once. Works for me. 

```
$ l ~/.oh-my-zsh/custom/plugins/awscnfm/_awscnfm
-rw-r--r-- 1 xh3b4sd staff 3.5K Jul  1 11:03 /Users/xh3b4sd/.oh-my-zsh/custom/plugins/awscnfm/_awscnfm
```

```
$ awscnfm generate                                                                                                                                                                                  giantswarm-gauss
action   -- Generate a new action sub command.
cluster  -- Generate a new cluster sub command.
```