### PR TITLE
move commands to make space for cluster creation

### DIFF
--- a/cmd/cl001/ac003/execute/zz_generated.command.go
+++ b/cmd/cl001/ac003/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac003 for cluster cl001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl001/ac003/execute/zz_generated.error.go
+++ b/cmd/cl001/ac003/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl001/ac003/execute/zz_generated.flag.go
+++ b/cmd/cl001/ac003/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl001/ac003/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac003/execute/zz_generated.runner.go
@@ -1,0 +1,78 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/pkg/action"
+	"github.com/giantswarm/awscnfm/pkg/action/cl001/ac003"
+	"github.com/giantswarm/awscnfm/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var clients *action.Clients
+	{
+		c := action.Config{
+			Logger: r.logger,
+
+			KubeConfig:    env.KubeConfig(),
+			TenantCluster: env.TenantCluster(),
+		}
+
+		clients, err = action.NewClients(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var e action.Executor
+	{
+		c := ac003.ExecutorConfig{
+			Clients: clients,
+			Logger:  r.logger,
+
+			TenantCluster: env.TenantCluster(),
+		}
+
+		e, err = ac003.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl001/ac003/explain/zz_generated.command.go
+++ b/cmd/cl001/ac003/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac003 for cluster cl001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl001/ac003/explain/zz_generated.error.go
+++ b/cmd/cl001/ac003/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl001/ac003/explain/zz_generated.flag.go
+++ b/cmd/cl001/ac003/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl001/ac003/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac003/explain/zz_generated.runner.go
@@ -1,0 +1,62 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/pkg/action"
+	"github.com/giantswarm/awscnfm/pkg/action/cl001/ac003"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac003.ExplainerConfig{}
+
+		e, err = ac003.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl001/ac003/zz_generated.command.go
+++ b/cmd/cl001/ac003/zz_generated.command.go
@@ -1,4 +1,4 @@
-package cl001
+package ac003
 
 import (
 	"io"
@@ -8,14 +8,13 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/cmd/cl001/ac001"
-	"github.com/giantswarm/awscnfm/cmd/cl001/ac002"
-	"github.com/giantswarm/awscnfm/cmd/cl001/ac003"
+	"github.com/giantswarm/awscnfm/cmd/cl001/ac003/execute"
+	"github.com/giantswarm/awscnfm/cmd/cl001/ac003/explain"
 )
 
 const (
-	name        = "cl001"
-	description = "Conformance tests for cluster cl001."
+	name        = "ac003"
+	description = "Action ac003 for cluster 001."
 )
 
 type Config struct {
@@ -37,43 +36,29 @@ func New(config Config) (*cobra.Command, error) {
 
 	var err error
 
-	var ac001Cmd *cobra.Command
+	var executeCmd *cobra.Command
 	{
-		c := ac001.Config{
+		c := execute.Config{
 			Logger: config.Logger,
 			Stderr: config.Stderr,
 			Stdout: config.Stdout,
 		}
 
-		ac001Cmd, err = ac001.New(c)
+		executeCmd, err = execute.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var ac002Cmd *cobra.Command
+	var explainCmd *cobra.Command
 	{
-		c := ac002.Config{
+		c := explain.Config{
 			Logger: config.Logger,
 			Stderr: config.Stderr,
 			Stdout: config.Stdout,
 		}
 
-		ac002Cmd, err = ac002.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var ac003Cmd *cobra.Command
-	{
-		c := ac003.Config{
-			Logger: config.Logger,
-			Stderr: config.Stderr,
-			Stdout: config.Stdout,
-		}
-
-		ac003Cmd, err = ac003.New(c)
+		explainCmd, err = explain.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -97,9 +82,8 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
-	c.AddCommand(ac001Cmd)
-	c.AddCommand(ac002Cmd)
-	c.AddCommand(ac003Cmd)
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
 
 	return c, nil
 }

--- a/cmd/cl001/ac003/zz_generated.error.go
+++ b/cmd/cl001/ac003/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac003
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl001/ac003/zz_generated.flag.go
+++ b/cmd/cl001/ac003/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac003
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl001/ac003/zz_generated.runner.go
+++ b/cmd/cl001/ac003/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac003
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions v0.2.0/go.mod h1:iw66G0WDcrQl9mi2m/6mov2fWTD6ZiT2+FC62b2Mczw=
+github.com/giantswarm/apiextensions v0.4.8/go.mod h1:iMZLjyvqRIVPTAQGbjwTSqifwrGB41a4mW8MwC45mYI=
 github.com/giantswarm/apiextensions v0.4.12 h1:pZyaUFLuZ87fuBjKQcgY1M7r81nlWe7KDgyorpOM1Do=
 github.com/giantswarm/apiextensions v0.4.12/go.mod h1:iMZLjyvqRIVPTAQGbjwTSqifwrGB41a4mW8MwC45mYI=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=

--- a/pkg/action/cl001/ac001/executor.go
+++ b/pkg/action/cl001/ac001/executor.go
@@ -2,69 +2,8 @@ package ac001
 
 import (
 	"context"
-	"fmt"
-
-	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
-	"github.com/giantswarm/microerror"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/giantswarm/awscnfm/pkg/label"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
-	var list corev1.NodeList
-	{
-		err := e.clients.TenantCluster.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var currentNodesReady int
-	for _, node := range list.Items {
-		_, ok := node.Labels[label.MasterNodeRole]
-		if !ok {
-			continue
-		}
-
-		for _, c := range node.Status.Conditions {
-			if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
-				currentNodesReady++
-			}
-		}
-	}
-
-	var desiredNodesReady int
-	{
-		var list infrastructurev1alpha2.G8sControlPlaneList
-		err := e.clients.ControlPlane.CtrlClient().List(
-			ctx,
-			&list,
-			client.MatchingLabels{label.Cluster: e.tenantCluster},
-		)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		for _, cr := range list.Items {
-			desiredNodesReady += cr.Spec.Replicas
-		}
-	}
-
-	if currentNodesReady != desiredNodesReady {
-		executionFailedError.Desc = fmt.Sprintf(
-			"The Tenant Cluster defines %d master nodes but it has only %d/%d healthy master nodes running.",
-			desiredNodesReady,
-			currentNodesReady,
-			desiredNodesReady,
-		)
-
-		return microerror.Mask(executionFailedError)
-	}
-
 	return nil
 }

--- a/pkg/action/cl001/ac001/explainer.go
+++ b/pkg/action/cl001/ac001/explainer.go
@@ -5,13 +5,5 @@ import (
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	s := `
-Check if the desired amount of Tenant Cluster master nodes are up and ready.
-
-	* Fetch all G8sControlPlane CRs spec.replicas so that we know how many masters the Tenant Cluster is supposed to have.
-	* Fetch the Tenant Cluster master nodes.
-	* Compare the current and desired amount of master nodes.
-	`
-
-	return s, nil
+	return "", nil
 }

--- a/pkg/action/cl001/ac002/explainer.go
+++ b/pkg/action/cl001/ac002/explainer.go
@@ -6,11 +6,11 @@ import (
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
 	s := `
-Check if the desired amount of Tenant Cluster worker nodes are up and ready.
+Check if the desired amount of Tenant Cluster master nodes are up and ready.
 
-	* Fetch all AWSMachineDeployment CRs spec.scaling.min so that we know how many workers the Tenant Cluster is supposed to have.
-	* Fetch the Tenant Cluster worker nodes.
-	* Compare the current and desired amount of worker nodes.
+	* Fetch all G8sControlPlane CRs spec.replicas so that we know how many masters the Tenant Cluster is supposed to have.
+	* Fetch the Tenant Cluster master nodes.
+	* Compare the current and desired amount of master nodes.
 	`
 
 	return s, nil

--- a/pkg/action/cl001/ac003/error.go
+++ b/pkg/action/cl001/ac003/error.go
@@ -1,4 +1,4 @@
-package ac001
+package ac003
 
 import "github.com/giantswarm/microerror"
 

--- a/pkg/action/cl001/ac003/executor.go
+++ b/pkg/action/cl001/ac003/executor.go
@@ -1,4 +1,4 @@
-package ac002
+package ac003
 
 import (
 	"context"
@@ -26,7 +26,7 @@ func (e *Executor) execute(ctx context.Context) error {
 
 	var currentNodesReady int
 	for _, node := range list.Items {
-		_, ok := node.Labels[label.MasterNodeRole]
+		_, ok := node.Labels[label.WorkerNodeRole]
 		if !ok {
 			continue
 		}
@@ -40,7 +40,7 @@ func (e *Executor) execute(ctx context.Context) error {
 
 	var desiredNodesReady int
 	{
-		var list infrastructurev1alpha2.G8sControlPlaneList
+		var list infrastructurev1alpha2.AWSMachineDeploymentList
 		err := e.clients.ControlPlane.CtrlClient().List(
 			ctx,
 			&list,
@@ -51,13 +51,13 @@ func (e *Executor) execute(ctx context.Context) error {
 		}
 
 		for _, cr := range list.Items {
-			desiredNodesReady += cr.Spec.Replicas
+			desiredNodesReady += cr.Spec.NodePool.Scaling.Min
 		}
 	}
 
 	if currentNodesReady != desiredNodesReady {
 		executionFailedError.Desc = fmt.Sprintf(
-			"The Tenant Cluster defines %d master nodes but it has only %d/%d healthy master nodes running.",
+			"The Tenant Cluster defines %d worker nodes but it has only %d/%d healthy worker nodes running.",
 			desiredNodesReady,
 			currentNodesReady,
 			desiredNodesReady,

--- a/pkg/action/cl001/ac003/explainer.go
+++ b/pkg/action/cl001/ac003/explainer.go
@@ -1,0 +1,17 @@
+package ac003
+
+import (
+	"context"
+)
+
+func (e *Explainer) explain(ctx context.Context) (string, error) {
+	s := `
+Check if the desired amount of Tenant Cluster worker nodes are up and ready.
+
+	* Fetch all AWSMachineDeployment CRs spec.scaling.min so that we know how many workers the Tenant Cluster is supposed to have.
+	* Fetch the Tenant Cluster worker nodes.
+	* Compare the current and desired amount of worker nodes.
+	`
+
+	return s, nil
+}

--- a/pkg/action/cl001/ac003/zz_generated.error.go
+++ b/pkg/action/cl001/ac003/zz_generated.error.go
@@ -1,0 +1,14 @@
+package ac003
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/action/cl001/ac003/zz_generated.executor.go
+++ b/pkg/action/cl001/ac003/zz_generated.executor.go
@@ -1,0 +1,55 @@
+package ac003
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/awscnfm/pkg/action"
+)
+
+type ExecutorConfig struct {
+	Clients *action.Clients
+	Logger  micrologger.Logger
+
+	TenantCluster string
+}
+
+type Executor struct {
+	clients *action.Clients
+	logger  micrologger.Logger
+
+	tenantCluster string
+}
+
+func NewExecutor(config ExecutorConfig) (*Executor, error) {
+	if config.Clients == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Clients must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.TenantCluster == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	e := &Executor{
+		clients: config.Clients,
+		logger:  config.Logger,
+
+		tenantCluster: config.TenantCluster,
+	}
+
+	return e, nil
+}
+
+func (e *Executor) Execute(ctx context.Context) error {
+	err := e.execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/action/cl001/ac003/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac003/zz_generated.explainer.go
@@ -1,0 +1,28 @@
+package ac003
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+type ExplainerConfig struct {
+}
+
+type Explainer struct {
+}
+
+func NewExplainer(config ExplainerConfig) (*Explainer, error) {
+	e := &Explainer{}
+
+	return e, nil
+}
+
+func (e *Explainer) Explain(ctx context.Context) (string, error) {
+	s, err := e.explain(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

One of our next steps is to implement an action that actually creates the Tenant Cluster we want to test. So this needs to be action `ac001`. This PR shifts the actions to make space for the new functionality. 