### PR TITLE
create cluster using first action

### DIFF
--- a/cmd/cl001/ac001/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac001/execute/zz_generated.runner.go
@@ -52,6 +52,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		err = clients.InitControlPlane(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	var e action.Executor

--- a/cmd/cl001/ac002/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac002/execute/zz_generated.runner.go
@@ -52,6 +52,16 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		err = clients.InitControlPlane(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = clients.InitTenantCluster(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	var e action.Executor

--- a/cmd/cl001/ac003/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac003/execute/zz_generated.runner.go
@@ -52,6 +52,16 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		err = clients.InitControlPlane(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = clients.InitTenantCluster(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	var e action.Executor

--- a/cmd/cl001/ac004/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac004/execute/zz_generated.runner.go
@@ -52,6 +52,16 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		err = clients.InitControlPlane(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = clients.InitTenantCluster(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	var e action.Executor

--- a/cmd/generate/action/template/cmd/execute/runner.go
+++ b/cmd/generate/action/template/cmd/execute/runner.go
@@ -62,6 +62,16 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		err = clients.InitControlPlane(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}{{ if ne .Action "ac001" }}
+
+		err = clients.InitTenantCluster(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}{{ end }}
 	}
 
 	var e action.Executor

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -7,11 +7,17 @@
 The tool should be structured so that it can execute any action against our
 Tenant Clusters. There might be many cluster definitions for which we have many
 actions each. The command line tool layout looks like shown below. In the
-schematic example `cl001` is the cluster tested for conformity based on a
-specific definition. All actions within that subcommand structure are
-exclusively designed for this particular cluster layout, so it can be specific
-to a single feature we want to test, e.g. single master clusters. In the example
-below `ac001` would provide subcommands to execute or explain the action itself.
+schematic example `cl001` is the cluster scope for testing conformity based on a
+specific tenant cluster definition. All actions within that subcommand structure
+are exclusively designed for this particular cluster scope, so it can be
+specific to a single feature we want to test, e.g. single master clusters. In
+the example below `ac001` would provide subcommands to execute or explain the
+action itself. Note that all actions defined within a certain cluster scope are
+meant to be open and generic. Any business logic can be implemented. The only
+assumption we make for the first action `ac001` is that it is meant to create
+the tenant cluster for its own particular cluster scope. This implies to not
+create a Kubernetes client for the tenant cluster when executing the first
+action of a given cluster scope.
 
 ```
 ├── cmd
@@ -39,11 +45,11 @@ silently exits with status code 0. In case the test failed an error is printed
 and the command exits with status code 1.
 
 ```
-$ awscnfm cl001 ac001 execute
+$ awscnfm cl001 ac007 execute
 ```
 
 ```
-$ awscnfm cl001 ac001 execute
+$ awscnfm cl001 ac007 execute
 The Tenant Cluster defines 3 master nodes but it has only 2/3 healthy master nodes running.
 ```
 
@@ -53,7 +59,7 @@ The Tenant Cluster defines 3 master nodes but it has only 2/3 healthy master nod
 ### Explain Tests
 
 ```
-$ awscnfm cl001 ac001 explain
+$ awscnfm cl001 ac007 explain
 Check if the desired amount of Tenant Cluster master nodes are up and ready.
 
 	* Fetch all G8sControlPlane CRs spec.replicas so that we know how many masters the Tenant Cluster is supposed to have.


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

With this we can implement the first action of a given cluster scope to define and create a Tenant Cluster. 

```
export AWSCNFM_TENANTCLUSTER=cl001
export AWSCNFM_KUBECONFIG=~/.kube/config
```

```
awscnfm cl001 ac001 execute
```

```
$ gsctl list clusters | grep cl001
cl001   giantswarm         awscnfm cluster cl001      12.0.0    2020 Jul 22, 14:43 UTC
```