### PR TITLE
fix linter issues

### DIFF
--- a/cmd/generate/action/runner.go
+++ b/cmd/generate/action/runner.go
@@ -155,7 +155,7 @@ func write(data actiontemplate.Data, templates [][]string, dirfmt string) error 
 		}
 
 		if write {
-			err = ioutil.WriteFile(path, buff.Bytes(), 0644)
+			err = ioutil.WriteFile(path, buff.Bytes(), 0644) // nolint:gosec
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/cmd/generate/cluster/runner.go
+++ b/cmd/generate/cluster/runner.go
@@ -109,7 +109,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 
-		err = ioutil.WriteFile(path, buff.Bytes(), 0644)
+		err = ioutil.WriteFile(path, buff.Bytes(), 0644) // nolint:gosec
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

I think I have a newer version of `golangci-lint` locally. So fixing this in advance. 

```
$ CGO_ENABLED=0 golangci-lint run -E gosec -E goconst
cmd/generate/cluster/runner.go:112:9: G306: Expect WriteFile permissions to be 0600 or less (gosec)
		err = ioutil.WriteFile(path, buff.Bytes(), 0644)
		      ^
cmd/generate/action/runner.go:158:10: G306: Expect WriteFile permissions to be 0600 or less (gosec)
			err = ioutil.WriteFile(path, buff.Bytes(), 0644)
			      ^
```

See https://gigantic.slack.com/archives/C3S23JE75/p1595507889147800. 