### PR TITLE
generate all actions at once

### DIFF
--- a/cmd/generate/action/flag.go
+++ b/cmd/generate/action/flag.go
@@ -14,18 +14,18 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.Action, "action", "a", "", "The name of the action to generate the sub command for, e.g. ac013.")
-	cmd.Flags().StringVarP(&f.Cluster, "cluster", "c", "", "The name of the cluster to generate the sub command for, e.g. cl001.")
+	cmd.Flags().StringVarP(&f.Action, "action", "a", "", "The name of the action to generate the subcommand for, e.g. ac013 or all to generate all actions.")
+	cmd.Flags().StringVarP(&f.Cluster, "cluster", "c", "", "The name of the cluster to generate the subcommand for, e.g. cl001.")
 }
 
 func (f *flag) Validate() error {
 	if f.Action == "" {
 		return microerror.Maskf(invalidFlagError, "-a/--action must not be empty")
 	}
-	if !strings.HasPrefix(f.Action, "ac") {
+	if f.Action != "all" && !strings.HasPrefix(f.Action, "ac") {
 		return microerror.Maskf(invalidFlagError, "-a/--action must have ac prefix, e.g. ac013, got %#q", f.Action)
 	}
-	if !regexp.MustCompile(`[0-9]{3}$`).MatchString(f.Action) {
+	if f.Action != "all" && !regexp.MustCompile(`[0-9]{3}$`).MatchString(f.Action) {
 		return microerror.Maskf(invalidFlagError, "-a/--action must have numbered suffix, e.g. ac013, got %#q", f.Action)
 	}
 

--- a/cmd/generate/action/flag.go
+++ b/cmd/generate/action/flag.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	allActions = "add"
+)
+
 type flag struct {
 	Action  string
 	Cluster string
@@ -22,10 +26,10 @@ func (f *flag) Validate() error {
 	if f.Action == "" {
 		return microerror.Maskf(invalidFlagError, "-a/--action must not be empty")
 	}
-	if f.Action != "all" && !strings.HasPrefix(f.Action, "ac") {
+	if f.Action != allActions && !strings.HasPrefix(f.Action, "ac") {
 		return microerror.Maskf(invalidFlagError, "-a/--action must have ac prefix, e.g. ac013, got %#q", f.Action)
 	}
-	if f.Action != "all" && !regexp.MustCompile(`[0-9]{3}$`).MatchString(f.Action) {
+	if f.Action != allActions && !regexp.MustCompile(`[0-9]{3}$`).MatchString(f.Action) {
 		return microerror.Maskf(invalidFlagError, "-a/--action must have numbered suffix, e.g. ac013, got %#q", f.Action)
 	}
 

--- a/cmd/generate/action/runner.go
+++ b/cmd/generate/action/runner.go
@@ -19,6 +19,7 @@ import (
 	templatecmdexecute "github.com/giantswarm/awscnfm/cmd/generate/action/template/cmd/execute"
 	templatecmdexplain "github.com/giantswarm/awscnfm/cmd/generate/action/template/cmd/explain"
 	templatepkgaction "github.com/giantswarm/awscnfm/cmd/generate/action/template/pkg/action"
+	"github.com/giantswarm/awscnfm/pkg/action"
 	"github.com/giantswarm/awscnfm/pkg/key"
 )
 
@@ -48,53 +49,67 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	data := actiontemplate.Data{
-		Action:  r.flag.Action,
-		Cluster: r.flag.Cluster,
-	}
+	var err error
 
-	{
-		// templates is a predefined list of lists for debugging reasons. When
-		// defining map[string]string for the key-value pairs the order of items
-		// changes since go maps are not deterministic.
-		templates := [][]string{
-			{templatecmdexecute.CommandBase, templatecmdexecute.CommandContent},
-			{templatecmdexecute.ErrorBase, templatecmdexecute.ErrorContent},
-			{templatecmdexecute.FlagBase, templatecmdexecute.FlagContent},
-			{templatecmdexecute.RunnerBase, templatecmdexecute.RunnerContent},
-
-			{templatecmdexplain.CommandBase, templatecmdexplain.CommandContent},
-			{templatecmdexplain.ErrorBase, templatecmdexplain.ErrorContent},
-			{templatecmdexplain.FlagBase, templatecmdexplain.FlagContent},
-			{templatecmdexplain.RunnerBase, templatecmdexplain.RunnerContent},
-
-			{templatecmd.CommandBase, templatecmd.CommandContent},
-			{templatecmd.ErrorBase, templatecmd.ErrorContent},
-			{templatecmd.FlagBase, templatecmd.FlagContent},
-			{templatecmd.RunnerBase, templatecmd.RunnerContent},
-		}
-
-		err := write(data, templates, "cmd/%s/%s")
+	var actions []string
+	if r.flag.Action == "all" {
+		actions, err = action.All(r.flag.Cluster)
 		if err != nil {
 			return microerror.Mask(err)
 		}
+	} else {
+		actions = append(actions, r.flag.Action)
 	}
 
-	{
-		// templates is a predefined list of lists for debugging reasons. When
-		// defining map[string]string for the key-value pairs the order of items
-		// changes since go maps are not deterministic.
-		templates := [][]string{
-			{templatepkgaction.ErrorBase, templatepkgaction.ErrorContent},
-			{templatepkgaction.ExecutorBase, templatepkgaction.ExecutorContent},
-			{templatepkgaction.ExecutorCustomBase, templatepkgaction.ExecutorCustomContent},
-			{templatepkgaction.ExplainerBase, templatepkgaction.ExplainerContent},
-			{templatepkgaction.ExplainerCustomBase, templatepkgaction.ExplainerCustomContent},
+	for _, a := range actions {
+		data := actiontemplate.Data{
+			Action:  a,
+			Cluster: r.flag.Cluster,
 		}
 
-		err := write(data, templates, "pkg/action/%s/%s")
-		if err != nil {
-			return microerror.Mask(err)
+		{
+			// templates is a predefined list of lists for debugging reasons. When
+			// defining map[string]string for the key-value pairs the order of items
+			// changes since go maps are not deterministic.
+			templates := [][]string{
+				{templatecmdexecute.CommandBase, templatecmdexecute.CommandContent},
+				{templatecmdexecute.ErrorBase, templatecmdexecute.ErrorContent},
+				{templatecmdexecute.FlagBase, templatecmdexecute.FlagContent},
+				{templatecmdexecute.RunnerBase, templatecmdexecute.RunnerContent},
+
+				{templatecmdexplain.CommandBase, templatecmdexplain.CommandContent},
+				{templatecmdexplain.ErrorBase, templatecmdexplain.ErrorContent},
+				{templatecmdexplain.FlagBase, templatecmdexplain.FlagContent},
+				{templatecmdexplain.RunnerBase, templatecmdexplain.RunnerContent},
+
+				{templatecmd.CommandBase, templatecmd.CommandContent},
+				{templatecmd.ErrorBase, templatecmd.ErrorContent},
+				{templatecmd.FlagBase, templatecmd.FlagContent},
+				{templatecmd.RunnerBase, templatecmd.RunnerContent},
+			}
+
+			err := write(data, templates, "cmd/%s/%s")
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		{
+			// templates is a predefined list of lists for debugging reasons. When
+			// defining map[string]string for the key-value pairs the order of items
+			// changes since go maps are not deterministic.
+			templates := [][]string{
+				{templatepkgaction.ErrorBase, templatepkgaction.ErrorContent},
+				{templatepkgaction.ExecutorBase, templatepkgaction.ExecutorContent},
+				{templatepkgaction.ExecutorCustomBase, templatepkgaction.ExecutorCustomContent},
+				{templatepkgaction.ExplainerBase, templatepkgaction.ExplainerContent},
+				{templatepkgaction.ExplainerCustomBase, templatepkgaction.ExplainerCustomContent},
+			}
+
+			err := write(data, templates, "pkg/action/%s/%s")
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 	}
 

--- a/cmd/generate/action/runner.go
+++ b/cmd/generate/action/runner.go
@@ -52,7 +52,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var err error
 
 	var actions []string
-	if r.flag.Action == "all" {
+	if r.flag.Action == allActions {
 		actions, err = action.All(r.flag.Cluster)
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/generate/cluster/runner.go
+++ b/cmd/generate/cluster/runner.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/giantswarm/microerror"
@@ -16,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	clustertemplate "github.com/giantswarm/awscnfm/cmd/generate/cluster/template"
+	"github.com/giantswarm/awscnfm/pkg/action"
 )
 
 type runner struct {
@@ -42,27 +42,13 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
 	var actions []string
 	{
-		path, err := filepath.Abs(fmt.Sprintf("cmd/%s", r.flag.Cluster))
+		actions, err = action.All(r.flag.Cluster)
 		if err != nil {
 			return microerror.Mask(err)
-		}
-
-		files, err := ioutil.ReadDir(path)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		for _, file := range files {
-			if !file.IsDir() {
-				continue
-			}
-			if !strings.HasPrefix(file.Name(), "ac") {
-				continue
-			}
-
-			actions = append(actions, file.Name())
 		}
 	}
 

--- a/pkg/action/all.go
+++ b/pkg/action/all.go
@@ -1,0 +1,38 @@
+package action
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+func All(cluster string) ([]string, error) {
+	var actions []string
+	{
+		path, err := filepath.Abs(fmt.Sprintf("cmd/%s", cluster))
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		files, err := ioutil.ReadDir(path)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		for _, file := range files {
+			if !file.IsDir() {
+				continue
+			}
+			if !strings.HasPrefix(file.Name(), "ac") {
+				continue
+			}
+
+			actions = append(actions, file.Name())
+		}
+	}
+
+	return actions, nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

I noticed the more actions we add the more legwork it is to re-generate all actions. In order to not have to do this tedious kind of work we add a way to generate all actions of a cluster scope at once. 