### PR TITLE
implement cluster deletion in ac004

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7
 	k8s.io/api v0.17.8
+	k8s.io/apimachinery v0.17.8
 	k8s.io/client-go v0.17.8
 	sigs.k8s.io/cluster-api v0.3.8
 	sigs.k8s.io/controller-runtime v0.5.9

--- a/pkg/action/cl001/ac000/plan.go
+++ b/pkg/action/cl001/ac000/plan.go
@@ -28,7 +28,7 @@ var Plan = []plan.Step{
 	},
 	{
 		Action:  "ac004",
-		Backoff: backoff.NewConstant(10*time.Second, 2*time.Second),
-		Comment: "not yet implemented",
+		Backoff: backoff.NewConstant(90*time.Minute, 9*time.Minute),
+		Comment: "delete cluster",
 	},
 }

--- a/pkg/action/cl001/ac004/error.go
+++ b/pkg/action/cl001/ac004/error.go
@@ -1,0 +1,22 @@
+package ac004
+
+import "github.com/giantswarm/microerror"
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var tooManyCRsError = &microerror.Error{
+	Kind: "tooManyCRsError",
+	Desc: "There is only a single AWSCluster CR allowed with the current implementation.",
+}
+
+// IsTooManyCRsError asserts tooManyCRsError.
+func IsTooManyCRsError(err error) bool {
+	return microerror.Cause(err) == tooManyCRsError
+}

--- a/pkg/action/cl001/ac004/executor.go
+++ b/pkg/action/cl001/ac004/executor.go
@@ -3,11 +3,12 @@ package ac004
 import (
 	"context"
 
-	"github.com/giantswarm/awscnfm/pkg/label"
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/awscnfm/pkg/label"
 )
 
 func (e *Executor) execute(ctx context.Context) error {

--- a/pkg/action/cl001/ac004/executor.go
+++ b/pkg/action/cl001/ac004/executor.go
@@ -2,8 +2,27 @@ package ac004
 
 import (
 	"context"
+
+	"github.com/giantswarm/awscnfm/pkg/label"
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
+	{
+		err := e.clients.ControlPlane.CtrlClient().DeleteAllOf(
+			ctx,
+			&apiv1alpha2.Cluster{},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
+		)
+		if errors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/action/cl001/ac004/explainer.go
+++ b/pkg/action/cl001/ac004/explainer.go
@@ -5,5 +5,16 @@ import (
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	return "", nil
+	s := `
+Delete the tenant cluster of the current cluster scope by triggering the
+deletion of the Cluster CR. This should ensure the following.
+
+	* Trigger deletion to all other CRs associated with the tenant cluster.
+	* Execute cleanup logic in all involved operators.
+	* Remove all cloud provider resources.
+	* Remove all CRs associated with the tenant cluster.
+
+`
+
+	return s, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

```
$ awscnfm cl001 ac004 explain
Delete the tenant cluster of the current cluster scope by triggering the
deletion of the Cluster CR. This should ensure the following.

	* Trigger deletion to all other CRs associated with the tenant cluster.
	* Execute cleanup logic in all involved operators.
	* Remove all cloud provider resources.
	* Remove all CRs associated with the tenant cluster.

```