### PR TITLE
create dir for generate cluster in case it does not exist

### DIFF
--- a/pkg/action/all.go
+++ b/pkg/action/all.go
@@ -3,6 +3,7 @@ package action
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -12,6 +13,16 @@ import (
 func All(cluster string) ([]string, error) {
 	var actions []string
 	{
+		_, err := os.Stat(fmt.Sprintf("cmd/%s", cluster))
+		if os.IsNotExist(err) {
+			err = os.Mkdir(fmt.Sprintf("cmd/%s", cluster), os.ModePerm)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		} else {
+			return nil, microerror.Mask(err)
+		}
+
 		path, err := filepath.Abs(fmt.Sprintf("cmd/%s", cluster))
 		if err != nil {
 			return nil, microerror.Mask(err)


### PR DESCRIPTION
When generating a new cluster it currently fails

```bash
awscnfm generate cluster -c cl002
panic: {"kind":"unknown","annotation":"open /Users/nick/github/giantswarm/awscnfm/cmd/cl002: no such file or directory","stack":[{"file":"/Users/nick/github/giantswarm/awscnfm/pkg/action/all.go","line":22},{"file":"/Users/nick/github/giantswarm/awscnfm/cmd/generate/cluster/runner.go","line":51},{"file":"/Users/nick/github/giantswarm/awscnfm/cmd/generate/cluster/runner.go","line":38},{"file":"/Users/nick/github/giantswarm/awscnfm/main.go","line":62}]}
```

In case it does not exist, we should create one for users.

## Checklist

- [ ] Update changelog in CHANGELOG.md.