### PR TITLE
Fix goimports for generate cluster

### DIFF
--- a/cmd/generate/cluster/template/command.go
+++ b/cmd/generate/cluster/template/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
-{{ range $a := .Actions }}
+{{- range $a := .Actions }}
 	"github.com/giantswarm/awscnfm/cmd/{{ $.Cluster }}/{{ $a }}"
 {{- end }}
 )
@@ -73,7 +73,7 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	f.Init(c)
-{{ range $a := .Actions }}
+{{- range $a := .Actions }}
 	c.AddCommand({{ $a }}Cmd)
 {{- end }}
 


### PR DESCRIPTION
When generating new cluster, CircleCI fails due to new lines, see #62.

```bash
#!/bin/bash -eo pipefail
go get golang.org/x/tools/cmd/goimports && if [[ -n $(goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -l .) ]]; then goimports -local github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} -d . && exit 1; fi
go: downloading golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6
go: found golang.org/x/tools/cmd/goimports in golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6
go: golang.org/x/tools upgrade => v0.0.0-20200731060945-b5fad4ed8dd6
go: downloading golang.org/x/mod v0.3.0
diff -u cmd/cl002/zz_generated.command.go.orig cmd/cl002/zz_generated.command.go
--- cmd/cl002/zz_generated.command.go.orig
+++ cmd/cl002/zz_generated.command.go
@@ -7,7 +7,6 @@
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
-
 )
 
 const (
@@ -51,7 +50,6 @@
 	}
 
 	f.Init(c)
-
 
 	return c, nil
 }

Exited with code exit status 1
CircleCI received exit code 1
```

Fixes creating new lines when actions are not present.

## Checklist

- [ ] Update changelog in CHANGELOG.md.