### PR TITLE
generate ac005 for cl001

### DIFF
--- a/cmd/cl001/ac005/execute/zz_generated.command.go
+++ b/cmd/cl001/ac005/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac005 for cluster cl001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl001/ac005/execute/zz_generated.error.go
+++ b/cmd/cl001/ac005/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl001/ac005/execute/zz_generated.flag.go
+++ b/cmd/cl001/ac005/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl001/ac005/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac005/execute/zz_generated.runner.go
@@ -1,0 +1,90 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/pkg/action"
+	"github.com/giantswarm/awscnfm/pkg/action/cl001/ac005"
+	"github.com/giantswarm/awscnfm/pkg/config"
+	"github.com/giantswarm/awscnfm/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var clients *action.Clients
+	{
+		c := action.Config{
+			Logger: r.logger,
+
+			KubeConfig:    env.KubeConfig(),
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
+
+		clients, err = action.NewClients(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = clients.InitControlPlane(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = clients.InitTenantCluster(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var e action.Executor
+	{
+		c := ac005.ExecutorConfig{
+			Clients: clients,
+			Command: cmd,
+			Logger:  r.logger,
+
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
+
+		e, err = ac005.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl001/ac005/explain/zz_generated.command.go
+++ b/cmd/cl001/ac005/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac005 for cluster cl001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl001/ac005/explain/zz_generated.error.go
+++ b/cmd/cl001/ac005/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl001/ac005/explain/zz_generated.flag.go
+++ b/cmd/cl001/ac005/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl001/ac005/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac005/explain/zz_generated.runner.go
@@ -1,0 +1,62 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/pkg/action"
+	"github.com/giantswarm/awscnfm/pkg/action/cl001/ac005"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac005.ExplainerConfig{}
+
+		e, err = ac005.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl001/ac005/zz_generated.command.go
+++ b/cmd/cl001/ac005/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac005
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/cmd/cl001/ac005/execute"
+	"github.com/giantswarm/awscnfm/cmd/cl001/ac005/explain"
+)
+
+const (
+	name        = "ac005"
+	description = "Action ac005 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl001/ac005/zz_generated.error.go
+++ b/cmd/cl001/ac005/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac005
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl001/ac005/zz_generated.flag.go
+++ b/cmd/cl001/ac005/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac005
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl001/ac005/zz_generated.runner.go
+++ b/cmd/cl001/ac005/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac005
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl001/zz_generated.command.go
+++ b/cmd/cl001/zz_generated.command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/awscnfm/cmd/cl001/ac002"
 	"github.com/giantswarm/awscnfm/cmd/cl001/ac003"
 	"github.com/giantswarm/awscnfm/cmd/cl001/ac004"
+	"github.com/giantswarm/awscnfm/cmd/cl001/ac005"
 )
 
 const (
@@ -109,6 +110,20 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var ac005Cmd *cobra.Command
+	{
+		c := ac005.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac005Cmd, err = ac005.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	f := &flag{}
 
 	r := &runner{
@@ -132,6 +147,7 @@ func New(config Config) (*cobra.Command, error) {
 	c.AddCommand(ac002Cmd)
 	c.AddCommand(ac003Cmd)
 	c.AddCommand(ac004Cmd)
+	c.AddCommand(ac005Cmd)
 
 	return c, nil
 }

--- a/pkg/action/cl001/ac005/executor.go
+++ b/pkg/action/cl001/ac005/executor.go
@@ -1,0 +1,9 @@
+package ac005
+
+import (
+	"context"
+)
+
+func (e *Executor) execute(ctx context.Context) error {
+	return nil
+}

--- a/pkg/action/cl001/ac005/explainer.go
+++ b/pkg/action/cl001/ac005/explainer.go
@@ -1,0 +1,9 @@
+package ac005
+
+import (
+	"context"
+)
+
+func (e *Explainer) explain(ctx context.Context) (string, error) {
+	return "", nil
+}

--- a/pkg/action/cl001/ac005/zz_generated.error.go
+++ b/pkg/action/cl001/ac005/zz_generated.error.go
@@ -1,0 +1,14 @@
+package ac005
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/action/cl001/ac005/zz_generated.executor.go
+++ b/pkg/action/cl001/ac005/zz_generated.executor.go
@@ -1,0 +1,62 @@
+package ac005
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/pkg/action"
+)
+
+type ExecutorConfig struct {
+	Clients *action.Clients
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	TenantCluster string
+}
+
+type Executor struct {
+	clients *action.Clients
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	tenantCluster string
+}
+
+func NewExecutor(config ExecutorConfig) (*Executor, error) {
+	if config.Clients == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Clients must not be empty", config)
+	}
+	if config.Command == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Command must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.TenantCluster == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	e := &Executor{
+		clients: config.Clients,
+		command: config.Command,
+		logger:  config.Logger,
+
+		tenantCluster: config.TenantCluster,
+	}
+
+	return e, nil
+}
+
+func (e *Executor) Execute(ctx context.Context) error {
+	err := e.execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/action/cl001/ac005/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac005/zz_generated.explainer.go
@@ -1,0 +1,28 @@
+package ac005
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+type ExplainerConfig struct {
+}
+
+type Explainer struct {
+}
+
+func NewExplainer(config ExplainerConfig) (*Explainer, error) {
+	e := &Explainer{}
+
+	return e, nil
+}
+
+func (e *Explainer) Explain(ctx context.Context) (string, error) {
+	s, err := e.explain(ctx)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

I would like to introduce a new action in between. Basically I want to insert a new ac002 directly after cluster creation to check for the Tenant Cluster being up. Though at first we have to add ac005 so that all existing actions can be moved around. This is kind of missing and screws up the plan execution. **The PR here is only generated code.** 