### PR TITLE
check cluster access in ac002

### DIFF
--- a/pkg/action/cl001/ac002/executor.go
+++ b/pkg/action/cl001/ac002/executor.go
@@ -2,8 +2,16 @@ package ac002
 
 import (
 	"context"
+
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
+	_, err := e.clients.TenantCluster.K8sClient().CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }

--- a/pkg/action/cl001/ac002/explainer.go
+++ b/pkg/action/cl001/ac002/explainer.go
@@ -5,5 +5,13 @@ import (
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	return "", nil
+	s := `
+Check if the Tenant Cluster is up and we can connect to it.
+
+	* List all Tenant Cluster nodes.
+	* Listing all Tenant Cluster nodes without errors means the apiserver is up.
+	* Proceed with further actions.
+	`
+
+	return s, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Follow up of https://github.com/giantswarm/awscnfm/pull/68. This here implements ac002 which got repurposed to check for cluster access directly after cluster creation. 