### PR TITLE
implement ac006 for checking if CRs are cleaned up during cluster deletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -19,7 +20,10 @@ func main() {
 	if err != nil {
 		mErr, ok := microerror.Cause(err).(*microerror.Error)
 		if ok && mErr.Desc != "" {
-			fmt.Println(mErr.Desc)
+			fmt.Println(strings.Title(err.Error()))
+			fmt.Println()
+			fmt.Println("    " + mErr.Desc)
+			fmt.Println()
 			os.Exit(1)
 		} else {
 			panic(microerror.JSON(err))

--- a/pkg/action/cl001/ac000/plan.go
+++ b/pkg/action/cl001/ac000/plan.go
@@ -12,7 +12,7 @@ var Plan = []plan.Step{
 	{
 		Action:  "ac001",
 		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
-		Comment: "create cluster",
+		Comment: "create cluster CRs",
 	},
 	{
 		Action:  "ac002",
@@ -31,7 +31,12 @@ var Plan = []plan.Step{
 	},
 	{
 		Action:  "ac005",
+		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Comment: "delete cluster CRs",
+	},
+	{
+		Action:  "ac006",
 		Backoff: plan.NewBackoff(90*time.Minute, 9*time.Minute),
-		Comment: "delete cluster",
+		Comment: "check CRs deleted",
 	},
 }

--- a/pkg/action/cl001/ac006/error.go
+++ b/pkg/action/cl001/ac006/error.go
@@ -1,0 +1,13 @@
+package ac006
+
+import "github.com/giantswarm/microerror"
+
+var customResourceCleanupError = &microerror.Error{
+	Kind: "customResourceCleanupError",
+	Desc: "We do not expect any CR to be found anymore since we want to ensure that cluster deletion cleans up properly.",
+}
+
+// IsCustomResourceCleanup asserts customResourceCleanupError.
+func IsCustomResourceCleanup(err error) bool {
+	return microerror.Cause(err) == customResourceCleanupError
+}

--- a/pkg/action/cl001/ac006/executor.go
+++ b/pkg/action/cl001/ac006/executor.go
@@ -2,8 +2,111 @@ package ac006
 
 import (
 	"context"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/microerror"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/awscnfm/pkg/label"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
+	{
+		var list apiv1alpha2.ClusterList
+		err := e.clients.ControlPlane.CtrlClient().List(
+			ctx,
+			&list,
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(list.Items) != 0 {
+			return microerror.Maskf(customResourceCleanupError, "Cluster")
+		}
+	}
+
+	{
+		var list infrastructurev1alpha2.AWSClusterList
+		err := e.clients.ControlPlane.CtrlClient().List(
+			ctx,
+			&list,
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(list.Items) != 0 {
+			return microerror.Maskf(customResourceCleanupError, "AWSCluster")
+		}
+	}
+
+	{
+		var list infrastructurev1alpha2.G8sControlPlaneList
+		err := e.clients.ControlPlane.CtrlClient().List(
+			ctx,
+			&list,
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(list.Items) != 0 {
+			return microerror.Maskf(customResourceCleanupError, "G8sControlPlane")
+		}
+	}
+
+	{
+		var list infrastructurev1alpha2.AWSControlPlaneList
+		err := e.clients.ControlPlane.CtrlClient().List(
+			ctx,
+			&list,
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(list.Items) != 0 {
+			return microerror.Maskf(customResourceCleanupError, "AWSControlPlane")
+		}
+	}
+
+	{
+		var list apiv1alpha2.MachineDeploymentList
+		err := e.clients.ControlPlane.CtrlClient().List(
+			ctx,
+			&list,
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(list.Items) != 0 {
+			return microerror.Maskf(customResourceCleanupError, "MachineDeployment")
+		}
+	}
+
+	{
+		var list infrastructurev1alpha2.AWSMachineDeploymentList
+		err := e.clients.ControlPlane.CtrlClient().List(
+			ctx,
+			&list,
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(list.Items) != 0 {
+			return microerror.Maskf(customResourceCleanupError, "AWSMachineDeployment")
+		}
+	}
+
 	return nil
 }

--- a/pkg/action/cl001/ac006/explainer.go
+++ b/pkg/action/cl001/ac006/explainer.go
@@ -5,5 +5,19 @@ import (
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	return "", nil
+	s := `
+Check that all relevant CRs of the tenant cluster management got properly
+cleaned up eventually during the transition of cluster deletion. This check
+considers the following CRs.
+
+	* Cluster
+	* AWSCluster
+	* G8sControlPlane
+	* AWSControlPlane
+	* MachineDeployment
+	* AWSMachineDeployment
+
+`
+
+	return s, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

I tested this on `gauss` since there are clusters running. The new action `ac006` checks if all CRs are gone. For a normally running cluster this command is expected to fail like shown below. 

```
$ export AWSCNFM_KUBECONFIG=~/.kube/config
$ export AWSCNFM_TENANTCLUSTER=6tjhj
```

```
$ awscnfm cl001 ac006 execute
Custom Resource Cleanup Error: Cluster

    We do not expect any CR to be found anymore since we want to ensure that cluster deletion cleans up properly.

```

```
$ awscnfm cl001 ac006 explain
Check that all relevant CRs of the tenant cluster management got properly
cleaned up eventually during the transition of cluster deletion. This check
considers the following CRs.

	* Cluster
	* AWSCluster
	* G8sControlPlane
	* AWSControlPlane
	* MachineDeployment
	* AWSMachineDeployment

```

Here we also added the new action to the plan. 

```
$ awscnfm cl001 ac000 explain
Execute the conformance test plan of this cluster scope. Actions below are
executed in order. A tenant cluster is conform if the plan executes without
errors. Plan execution might take up to 1h54m40s.

ACTION  RETRY  WAIT     COMMENT
ac001   2s     10s      create cluster CRs
ac002   3m0s   24m0s    check cluster access
ac003   2s     10s      check master count
ac004   2s     10s      check worker count
ac005   2s     10s      delete cluster CRs
ac006   9m0s   1h30m0s  check CRs deleted

```