### PR TITLE
add structure for insert command

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/awscnfm/cmd/cl001"
 	"github.com/giantswarm/awscnfm/cmd/completion"
 	"github.com/giantswarm/awscnfm/cmd/generate"
+	"github.com/giantswarm/awscnfm/cmd/insert"
 	"github.com/giantswarm/awscnfm/cmd/version"
 	"github.com/giantswarm/awscnfm/pkg/project"
 )
@@ -106,6 +107,20 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var insertCmd *cobra.Command
+	{
+		c := insert.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		insertCmd, err = insert.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var versionCmd *cobra.Command
 	{
 		c := version.Config{
@@ -128,6 +143,7 @@ func New(config Config) (*cobra.Command, error) {
 	m.AddCommand(cl001Cmd)
 	m.AddCommand(completionCmd)
 	m.AddCommand(generateCmd)
+	m.AddCommand(insertCmd)
 	m.AddCommand(versionCmd)
 
 	return m, nil

--- a/cmd/insert/action/command.go
+++ b/cmd/insert/action/command.go
@@ -1,0 +1,53 @@
+package action
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "action"
+	description = "Insert a new action in between established lists of actions."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/insert/action/error.go
+++ b/cmd/insert/action/error.go
@@ -1,0 +1,21 @@
+package action
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagError = &microerror.Error{
+	Kind: "invalidFlagError",
+}
+
+// IsInvalidFlag asserts invalidFlagsError.
+func IsInvalidFlag(err error) bool {
+	return microerror.Cause(err) == invalidFlagError
+}

--- a/cmd/insert/action/flag.go
+++ b/cmd/insert/action/flag.go
@@ -1,0 +1,47 @@
+package action
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+)
+
+const (
+	allActions = "all"
+)
+
+type flag struct {
+	Action  string
+	Cluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.Action, "action", "a", "", "The name of the action to generate the subcommand for, e.g. ac013 or all to generate all actions.")
+	cmd.Flags().StringVarP(&f.Cluster, "cluster", "c", "", "The name of the cluster to generate the subcommand for, e.g. cl001.")
+}
+
+func (f *flag) Validate() error {
+	if f.Action == "" {
+		return microerror.Maskf(invalidFlagError, "-a/--action must not be empty")
+	}
+	if f.Action != allActions && !strings.HasPrefix(f.Action, "ac") {
+		return microerror.Maskf(invalidFlagError, "-a/--action must have ac prefix, e.g. ac013, got %#q", f.Action)
+	}
+	if f.Action != allActions && !regexp.MustCompile(`[0-9]{3}$`).MatchString(f.Action) {
+		return microerror.Maskf(invalidFlagError, "-a/--action must have numbered suffix, e.g. ac013, got %#q", f.Action)
+	}
+
+	if f.Cluster == "" {
+		return microerror.Maskf(invalidFlagError, "-c/--cluster must not be empty")
+	}
+	if !strings.HasPrefix(f.Cluster, "cl") {
+		return microerror.Maskf(invalidFlagError, "-c/--cluster must have cl prefix, e.g. cl001, got %#q", f.Cluster)
+	}
+	if !regexp.MustCompile(`[0-9]{3}$`).MatchString(f.Cluster) {
+		return microerror.Maskf(invalidFlagError, "-c/--cluster must have numbered suffix, e.g. cl001, got %#q", f.Cluster)
+	}
+
+	return nil
+}

--- a/cmd/insert/action/runner.go
+++ b/cmd/insert/action/runner.go
@@ -1,0 +1,39 @@
+package action
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	var err error
+
+	ctx := context.Background()
+
+	err = r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/insert/command.go
+++ b/cmd/insert/command.go
@@ -1,0 +1,73 @@
+package insert
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/cmd/insert/action"
+)
+
+const (
+	name        = "insert"
+	description = "Insert actions in between established lists of actions."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var actionCmd *cobra.Command
+	{
+		c := action.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		actionCmd, err = action.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(actionCmd)
+
+	return c, nil
+}

--- a/cmd/insert/error.go
+++ b/cmd/insert/error.go
@@ -1,0 +1,21 @@
+package insert
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/insert/flag.go
+++ b/cmd/insert/flag.go
@@ -1,0 +1,13 @@
+package insert
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/insert/runner.go
+++ b/cmd/insert/runner.go
@@ -1,0 +1,42 @@
+package insert
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Coming from https://gigantic.slack.com/archives/C7865GLSY/p1597218860004100. We want to have an `insert` command in order to inject new/empty actions in between. This PR only adds the command structure. Business logic follows in the next PRs. 