### PR TITLE
Fix binary naming in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 PACKAGE_DIR    := ./bin-dist
 
-APPLICATION    := $(shell basename $(shell go list .))
+APPLICATION    := $(shell go list . | cut -d '/' -f 3)
 BUILDTIMESTAMP := $(shell date -u '+%FT%TZ')
 GITSHA1        := $(shell git rev-parse --verify HEAD)
 OS             := $(shell go env GOOS)

--- a/cmd/insert/action/runner.go
+++ b/cmd/insert/action/runner.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
 )
 
 type runner struct {


### PR DESCRIPTION
Pulls in the fix made in https://github.com/giantswarm/devctl/pull/92

Also fixes a broken import in the "insert" command. 