### PR TITLE
include namespace to delete cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add first cluster scope and actions.
 * New action to verifiy if host network pods matches with k8scloudconfig on master nodes
 
+### Fixed
+
+* Include namespace to delete cluster CR's
+
 [Unreleased]: https://github.com/giantswarm/awscnfm/compare/v12.1.0...HEAD
 [12.1.0]: https://github.com/giantswarm/awscnfm/releases/tag/v12.1.0

--- a/pkg/action/cl001/ac008/executor.go
+++ b/pkg/action/cl001/ac008/executor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,6 +17,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := e.clients.ControlPlane.CtrlClient().DeleteAllOf(
 			ctx,
 			&apiv1alpha2.Cluster{},
+			client.InNamespace(metav1.NamespaceDefault),
 			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
when running action 008, it should delete the test cluster but it was not working.
I was debugging and looking why it didn't work, adding logging in not found error
it says:
```
the server could not find the requested resource (delete clusters.cluster.x-k8s.io)
```

after I added the namespace I was able to delete the cluster.


## Checklist

- [x] Update changelog in CHANGELOG.md.