### PR TITLE
Drop tenant cluster initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Include namespace to delete cluster CR's
+* Drop tenant cluster initialization in cleaner verification action
 
 [Unreleased]: https://github.com/giantswarm/awscnfm/compare/v12.1.1...HEAD
 [12.1.1]: https://github.com/giantswarm/awscnfm/compare/v12.1.0...v12.1.1

--- a/cmd/cl001/ac009/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac009/execute/zz_generated.runner.go
@@ -58,11 +58,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		err = clients.InitTenantCluster(ctx)
-		if err != nil {
-			return microerror.Mask(err)
-		}
 	}
 
 	var e action.Executor


### PR DESCRIPTION
Currently panics in the last step due to the InitTenantCluster, but the cluster has been already evicted.

```golang
panic: {"kind":"notFoundError","stack":[{"file":"/Users/nick/github/giantswarm/awscnfm/pkg/action/client.go","line":109},{"file":"/Users/nick/github/giantswarm/awscnfm/cmd/cl001/ac009/execute/zz_generated.runner.go","line":64},{"file":"/Users/nick/github/giantswarm/awscnfm/cmd/cl001/ac009/execute/zz_generated.runner.go","line":34},{"file":"/Users/nick/github/giantswarm/awscnfm/main.go","line":66}]}

goroutine 1 [running]:
main.main()
	/Users/nick/github/giantswarm/awscnfm/main.go:29 +0x29d
```

## Checklist

- [x] Update changelog in CHANGELOG.md.