### PR TITLE
generate tenant id

### DIFF
--- a/cmd/cl001/ac000/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac000/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac000"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac000.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac000.NewExecutor(c)

--- a/cmd/cl001/ac000/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac000/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac000"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac000.ExplainerConfig{}
+		c := ac000.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac000.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac001/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac001/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac001"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac001.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac001.NewExecutor(c)

--- a/cmd/cl001/ac001/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac001/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac001"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac001.ExplainerConfig{}
+		c := ac001.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac001.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac002/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac002/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac002"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac002.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac002.NewExecutor(c)

--- a/cmd/cl001/ac002/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac002/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac002"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac002.ExplainerConfig{}
+		c := ac002.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac002.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac003/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac003/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac003"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac003.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac003.NewExecutor(c)

--- a/cmd/cl001/ac003/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac003/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac003"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac003.ExplainerConfig{}
+		c := ac003.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac003.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac004/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac004/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac004"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac004.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac004.NewExecutor(c)

--- a/cmd/cl001/ac004/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac004/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac004"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac004.ExplainerConfig{}
+		c := ac004.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac004.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac005/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac005/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac005"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac005.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac005.NewExecutor(c)

--- a/cmd/cl001/ac005/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac005/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac005"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac005.ExplainerConfig{}
+		c := ac005.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac005.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac006/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac006/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac006"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac006.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac006.NewExecutor(c)

--- a/cmd/cl001/ac006/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac006/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac006"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac006.ExplainerConfig{}
+		c := ac006.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac006.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac007/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac007/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac007"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac007.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac007.NewExecutor(c)

--- a/cmd/cl001/ac007/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac007/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac007"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac007.ExplainerConfig{}
+		c := ac007.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac007.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac008/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac008/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac008"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac008.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac008.NewExecutor(c)

--- a/cmd/cl001/ac008/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac008/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac008"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac008.ExplainerConfig{}
+		c := ac008.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac008.NewExplainer(c)
 		if err != nil {

--- a/cmd/cl001/ac009/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac009/execute/zz_generated.runner.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac009"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -41,8 +43,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac009.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = ac009.NewExecutor(c)

--- a/cmd/cl001/ac009/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac009/explain/zz_generated.runner.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/cl001/ac009"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -42,7 +44,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := ac009.ExplainerConfig{}
+		c := ac009.ExplainerConfig{
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
+		}
 
 		e, err = ac009.NewExplainer(c)
 		if err != nil {

--- a/cmd/generate/action/template/cmd/execute/runner.go
+++ b/cmd/generate/action/template/cmd/execute/runner.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/{{ .Cluster }}/{{ .Action }}"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -51,8 +53,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := {{ .Action }}.ExecutorConfig{
-			Command: cmd,
-			Logger:  r.logger,
+			Command:       cmd,
+			Logger:        r.logger,
+			TenantCluster: config.Cluster("{{ .Cluster }}", env.TenantCluster()),
 		}
 
 		e, err = {{ .Action }}.NewExecutor(c)

--- a/cmd/generate/action/template/cmd/explain/runner.go
+++ b/cmd/generate/action/template/cmd/explain/runner.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/pkg/action"
 	"github.com/giantswarm/awscnfm/v12/pkg/action/{{ .Cluster }}/{{ .Action }}"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 type runner struct {
@@ -52,7 +54,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var e action.Explainer
 	{
-		c := {{ .Action }}.ExplainerConfig{}
+		c := {{ .Action }}.ExplainerConfig{
+			TenantCluster: config.Cluster("{{ .Cluster }}", env.TenantCluster()),
+		}
 
 		e, err = {{ .Action }}.NewExplainer(c)
 		if err != nil {

--- a/cmd/generate/action/template/pkg/action/executor.go
+++ b/cmd/generate/action/template/pkg/action/executor.go
@@ -19,13 +19,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -37,8 +39,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/cmd/generate/action/template/pkg/action/explainer.go
+++ b/cmd/generate/action/template/pkg/action/explainer.go
@@ -25,13 +25,17 @@ const (
 {{ end -}}
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac000/zz_generated.executor.go
+++ b/pkg/action/cl001/ac000/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac000/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac000/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac001/zz_generated.executor.go
+++ b/pkg/action/cl001/ac001/zz_generated.executor.go
@@ -11,13 +11,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -29,8 +31,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac001/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac001/zz_generated.explainer.go
@@ -14,13 +14,17 @@ const (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac002/zz_generated.executor.go
+++ b/pkg/action/cl001/ac002/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac002/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac002/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac003/zz_generated.executor.go
+++ b/pkg/action/cl001/ac003/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac003/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac003/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac004/zz_generated.executor.go
+++ b/pkg/action/cl001/ac004/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac004/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac004/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac005/zz_generated.executor.go
+++ b/pkg/action/cl001/ac005/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac005/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac005/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac006/zz_generated.executor.go
+++ b/pkg/action/cl001/ac006/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac006/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac006/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac007/zz_generated.executor.go
+++ b/pkg/action/cl001/ac007/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac007/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac007/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac008/zz_generated.executor.go
+++ b/pkg/action/cl001/ac008/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac008/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac008/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }

--- a/pkg/action/cl001/ac009/zz_generated.executor.go
+++ b/pkg/action/cl001/ac009/zz_generated.executor.go
@@ -9,13 +9,15 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command *cobra.Command
-	Logger  micrologger.Logger
+	Command       *cobra.Command
+	Logger        micrologger.Logger
+	TenantCluster string
 }
 
 type Executor struct {
-	command *cobra.Command
-	logger  micrologger.Logger
+	command       *cobra.Command
+	logger        micrologger.Logger
+	tenantCluster string
 }
 
 func NewExecutor(config ExecutorConfig) (*Executor, error) {
@@ -27,8 +29,9 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command: config.Command,
-		logger:  config.Logger,
+		command:       config.Command,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
 	}
 
 	return e, nil

--- a/pkg/action/cl001/ac009/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac009/zz_generated.explainer.go
@@ -7,13 +7,17 @@ import (
 )
 
 type ExplainerConfig struct {
+	TenantCluster string
 }
 
 type Explainer struct {
+	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
-	e := &Explainer{}
+	e := &Explainer{
+		tenantCluster: config.TenantCluster,
+	}
 
 	return e, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.


## Context 

With the latest changes around client management we got a bit of an ugly situation with the tenant cluster ID. We thought it makes sense to generate the code in a way that custom code does not have to deal with the magic scope strings. The template changes and the generated code are in separate commits. 