### PR TITLE
use configured tenant cluster id

### DIFF
--- a/pkg/action/cl001/ac003/executor.go
+++ b/pkg/action/cl001/ac003/executor.go
@@ -11,16 +11,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/config"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
 	var err error
-
-	scope := "cl001"
-	id := config.Cluster(scope, env.TenantCluster())
 
 	var cpClients k8sclient.Interface
 	{
@@ -40,7 +35,7 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: scope,
+			Scope: "cl001",
 		}
 
 		tcClients, err = pkgclient.NewTenantCluster(c)
@@ -80,7 +75,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if err != nil {
 			return microerror.Mask(err)

--- a/pkg/action/cl001/ac004/executor.go
+++ b/pkg/action/cl001/ac004/executor.go
@@ -11,16 +11,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/config"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
 	var err error
-
-	scope := "cl001"
-	id := config.Cluster(scope, env.TenantCluster())
 
 	var cpClients k8sclient.Interface
 	{
@@ -40,7 +35,7 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: scope,
+			Scope: "cl001",
 		}
 
 		tcClients, err = pkgclient.NewTenantCluster(c)
@@ -80,7 +75,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if err != nil {
 			return microerror.Mask(err)

--- a/pkg/action/cl001/ac005/executor.go
+++ b/pkg/action/cl001/ac005/executor.go
@@ -8,14 +8,9 @@ import (
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/config"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
-	scope := "cl001"
-	id := config.Cluster(scope, env.TenantCluster())
-
 	var err error
 
 	var cpClients k8sclient.Interface
@@ -44,7 +39,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		releases = list.Items
 	}
 
-	crs, err := newCRs(ctx, releases, id, cpClients.RESTConfig().Host)
+	crs, err := newCRs(ctx, releases, e.tenantCluster, cpClients.RESTConfig().Host)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/action/cl001/ac008/executor.go
+++ b/pkg/action/cl001/ac008/executor.go
@@ -11,16 +11,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/config"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
 	var err error
-
-	scope := "cl001"
-	id := config.Cluster(scope, env.TenantCluster())
 
 	var cpClients k8sclient.Interface
 	{
@@ -39,7 +34,7 @@ func (e *Executor) execute(ctx context.Context) error {
 			ctx,
 			&apiv1alpha2.Cluster{},
 			client.InNamespace(metav1.NamespaceDefault),
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if errors.IsNotFound(err) {
 			// fall through

--- a/pkg/action/cl001/ac009/executor.go
+++ b/pkg/action/cl001/ac009/executor.go
@@ -10,16 +10,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/config"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
 	var err error
-
-	scope := "cl001"
-	id := config.Cluster(scope, env.TenantCluster())
 
 	var cpClients k8sclient.Interface
 	{
@@ -38,7 +33,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if err != nil {
 			return microerror.Mask(err)
@@ -54,7 +49,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if err != nil {
 			return microerror.Mask(err)
@@ -70,7 +65,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if err != nil {
 			return microerror.Mask(err)
@@ -86,7 +81,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if err != nil {
 			return microerror.Mask(err)
@@ -102,7 +97,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 		if err != nil {
 			return microerror.Mask(err)
@@ -118,7 +113,7 @@ func (e *Executor) execute(ctx context.Context) error {
 		err := cpClients.CtrlClient().List(
 			ctx,
 			&list,
-			client.MatchingLabels{label.Cluster: id},
+			client.MatchingLabels{label.Cluster: e.tenantCluster},
 		)
 
 		if err != nil {


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

In https://github.com/giantswarm/awscnfm/pull/111 we generated the tenant cluster ID. Here we make use of it now. 