### PR TITLE
Generate scope

### DIFF
--- a/cmd/cl001/ac000/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac000/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac000.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac000/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac000/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac000.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac001/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac001/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac001.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac001/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac001/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac001.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac002/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac002/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac002.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac002/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac002/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac002.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac003/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac003/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac003.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac003/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac003/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac003.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac004/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac004/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac004.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac004/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac004/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac004.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac005/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac005/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac005.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac005/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac005/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac005.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac006/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac006/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac006.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac006/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac006/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac006.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac007/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac007/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac007.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac007/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac007/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac007.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac008/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac008/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac008.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac008/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac008/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac008.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac009/execute/zz_generated.runner.go
+++ b/cmd/cl001/ac009/execute/zz_generated.runner.go
@@ -43,8 +43,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := ac009.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/cl001/ac009/explain/zz_generated.runner.go
+++ b/cmd/cl001/ac009/explain/zz_generated.runner.go
@@ -45,6 +45,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := ac009.ExplainerConfig{
+			Scope:         "cl001",
 			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 

--- a/cmd/generate/action/template/cmd/execute/runner.go
+++ b/cmd/generate/action/template/cmd/execute/runner.go
@@ -53,9 +53,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Executor
 	{
 		c := {{ .Action }}.ExecutorConfig{
-			Command:       cmd,
-			Logger:        r.logger,
-			TenantCluster: config.Cluster("{{ .Cluster }}", env.TenantCluster()),
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl001",
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = {{ .Action }}.NewExecutor(c)

--- a/cmd/generate/action/template/cmd/explain/runner.go
+++ b/cmd/generate/action/template/cmd/explain/runner.go
@@ -55,7 +55,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var e action.Explainer
 	{
 		c := {{ .Action }}.ExplainerConfig{
-			TenantCluster: config.Cluster("{{ .Cluster }}", env.TenantCluster()),
+			Scope:         "cl001",
+			TenantCluster: config.Cluster("cl001", env.TenantCluster()),
 		}
 
 		e, err = {{ .Action }}.NewExplainer(c)

--- a/cmd/generate/action/template/pkg/action/executor.go
+++ b/cmd/generate/action/template/pkg/action/executor.go
@@ -19,14 +19,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -39,8 +43,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/cmd/generate/action/template/pkg/action/explainer.go
+++ b/cmd/generate/action/template/pkg/action/explainer.go
@@ -25,15 +25,18 @@ const (
 {{ end -}}
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac000/zz_generated.executor.go
+++ b/pkg/action/cl001/ac000/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac000/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac000/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac001/zz_generated.executor.go
+++ b/pkg/action/cl001/ac001/zz_generated.executor.go
@@ -11,14 +11,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -31,8 +35,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac001/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac001/zz_generated.explainer.go
@@ -14,15 +14,18 @@ const (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac002/zz_generated.executor.go
+++ b/pkg/action/cl001/ac002/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac002/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac002/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac003/zz_generated.executor.go
+++ b/pkg/action/cl001/ac003/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac003/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac003/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac004/zz_generated.executor.go
+++ b/pkg/action/cl001/ac004/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac004/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac004/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac005/zz_generated.executor.go
+++ b/pkg/action/cl001/ac005/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac005/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac005/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac006/zz_generated.executor.go
+++ b/pkg/action/cl001/ac006/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac006/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac006/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac007/zz_generated.executor.go
+++ b/pkg/action/cl001/ac007/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac007/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac007/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac008/zz_generated.executor.go
+++ b/pkg/action/cl001/ac008/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac008/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac008/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac009/zz_generated.executor.go
+++ b/pkg/action/cl001/ac009/zz_generated.executor.go
@@ -9,14 +9,18 @@ import (
 )
 
 type ExecutorConfig struct {
-	Command       *cobra.Command
-	Logger        micrologger.Logger
+	Command *cobra.Command
+	Logger  micrologger.Logger
+
+	Scope         string
 	TenantCluster string
 }
 
 type Executor struct {
-	command       *cobra.Command
-	logger        micrologger.Logger
+	command *cobra.Command
+	logger  micrologger.Logger
+
+	scope         string
 	tenantCluster string
 }
 
@@ -29,8 +33,10 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 	}
 
 	e := &Executor{
-		command:       config.Command,
-		logger:        config.Logger,
+		command: config.Command,
+		logger:  config.Logger,
+
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 

--- a/pkg/action/cl001/ac009/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac009/zz_generated.explainer.go
@@ -7,15 +7,18 @@ import (
 )
 
 type ExplainerConfig struct {
+	Scope         string
 	TenantCluster string
 }
 
 type Explainer struct {
+	scope         string
 	tenantCluster string
 }
 
 func NewExplainer(config ExplainerConfig) (*Explainer, error) {
 	e := &Explainer{
+		scope:         config.Scope,
 		tenantCluster: config.TenantCluster,
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Following up on the client management improvements we had some ugly code within the actions where you had to define the cluster scope yourself. With this PR this bit of information is generated. Next PR will use the generated scope information within the actions. 