### PR TITLE
fix action generation when starting out

### DIFF
--- a/cmd/generate/action/template/pkg/action/explainer.go
+++ b/cmd/generate/action/template/pkg/action/explainer.go
@@ -22,6 +22,12 @@ const (
 	explainerCommand = "awscnfm {{ .Cluster }} {{ .Action }} explain"
 )
 
+const (
+	// This is a hack to make initially generated code compile because there is
+	// nothing making use of the constant when starting out.
+	_ = explainerCommand
+)
+
 {{ end -}}
 
 type ExplainerConfig struct {

--- a/pkg/action/cl001/ac001/zz_generated.explainer.go
+++ b/pkg/action/cl001/ac001/zz_generated.explainer.go
@@ -13,6 +13,12 @@ const (
 	explainerCommand = "awscnfm cl001 ac001 explain"
 )
 
+const (
+	// This is a hack to make initially generated code compile because there is
+	// nothing making use of the constant when starting out.
+	_ = explainerCommand
+)
+
 type ExplainerConfig struct {
 	Scope         string
 	TenantCluster string


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

In https://github.com/giantswarm/awscnfm/pull/123 we noticed that the generated constants we use for documentation purposes are not used when generating new actions. In order to fix this we define a fake constant to just use the documentation constant for assignment. 