### PR TITLE
implement cluster creation in ac001 of cluster scope cl002

### DIFF
--- a/pkg/action/cl002/ac001/crs.go
+++ b/pkg/action/cl002/ac001/crs.go
@@ -1,0 +1,50 @@
+package ac001
+
+import (
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
+	"github.com/giantswarm/awscnfm/v12/pkg/project"
+	"github.com/giantswarm/awscnfm/v12/pkg/release"
+)
+
+func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, error) {
+	var err error
+
+	var p *release.Patch
+	{
+		c := release.PatchConfig{
+			FromEnv:     env.ReleaseVersion(),
+			FromProject: project.Version(),
+			Releases:    releases,
+		}
+
+		p, err = release.NewPatch(c)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+	}
+
+	var crs v1alpha2.ClusterCRs
+	{
+		c := v1alpha2.ClusterCRsConfig{
+			Credential:        key.Credential,
+			Domain:            key.DomainFromHost(host),
+			Description:       explainerCommand,
+			Owner:             key.Organization,
+			Region:            key.RegionFromHost(host),
+			ReleaseComponents: p.Components(),
+			ReleaseVersion:    p.Version(),
+		}
+
+		crs, err = v1alpha2.NewClusterCRs(c)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+	}
+
+	return crs, nil
+}

--- a/pkg/action/cl002/ac001/executor.go
+++ b/pkg/action/cl002/ac001/executor.go
@@ -4,8 +4,68 @@ import (
 	"context"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
 )
 
 func (e *Executor) execute(ctx context.Context) (v1alpha2.ClusterCRs, error) {
-	return v1alpha2.ClusterCRs{}, nil
+	var err error
+
+	var cpClients k8sclient.Interface
+	{
+		c := client.ControlPlaneConfig{
+			Logger: e.logger,
+		}
+
+		cpClients, err = client.NewControlPlane(c)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+	}
+
+	var releases []v1alpha1.Release
+	{
+		var list v1alpha1.ReleaseList
+		err := cpClients.CtrlClient().List(
+			ctx,
+			&list,
+		)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+
+		releases = list.Items
+	}
+
+	crs, err := newCRs(releases, cpClients.RESTConfig().Host)
+	if err != nil {
+		return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+	}
+
+	{
+		err = cpClients.CtrlClient().Create(ctx, crs.Cluster)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+
+		err = cpClients.CtrlClient().Create(ctx, crs.AWSCluster)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+
+		err = cpClients.CtrlClient().Create(ctx, crs.G8sControlPlane)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+
+		err = cpClients.CtrlClient().Create(ctx, crs.AWSControlPlane)
+		if err != nil {
+			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
+		}
+	}
+
+	return crs, nil
 }

--- a/pkg/action/cl002/ac001/explainer.go
+++ b/pkg/action/cl002/ac001/explainer.go
@@ -2,8 +2,85 @@ package ac001
 
 import (
 	"context"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	return "", nil
+	var err error
+
+	var cpClients k8sclient.Interface
+	{
+		c := client.ControlPlaneConfig{
+			Logger: microloggertest.New(),
+		}
+
+		cpClients, err = client.NewControlPlane(c)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	var releases []v1alpha1.Release
+	{
+		var list v1alpha1.ReleaseList
+		err := cpClients.CtrlClient().List(
+			ctx,
+			&list,
+		)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		releases = list.Items
+	}
+
+	crs, err := newCRs(releases, "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	clusterCR, err := yaml.Marshal(crs.Cluster)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	awsClusterCR, err := yaml.Marshal(crs.AWSCluster)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	g8sControlPlaneCR, err := yaml.Marshal(crs.G8sControlPlane)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	awsControlPlaneCR, err := yaml.Marshal(crs.AWSControlPlane)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	s := `
+Create a basic Tenant Cluster with all its defaults. Note that some
+information of the output below slightly differs when executing conformance
+tests on different control planes.
+
+---
+` + strings.TrimSpace(string(clusterCR)) + `
+---
+` + strings.TrimSpace(string(awsClusterCR)) + `
+---
+` + strings.TrimSpace(string(g8sControlPlaneCR)) + `
+---
+` + strings.TrimSpace(string(awsControlPlaneCR)) + `
+	`
+
+	return s, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

This PR implements cluster creation for the new cluster scope. The code is identical to the cluster creation in cluster scope `cl001`. I noticed I have to change the release version lookup for patch releases again. Will do this in the following PRs. 