### PR TITLE
fix release resolver

### DIFF
--- a/pkg/release/major.go
+++ b/pkg/release/major.go
@@ -98,6 +98,10 @@ func mustFindMajors(version string, releases []v1alpha1.Release) (v1alpha1.Relea
 func mustFindLatestMajor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
 
+	if vv.PreRelease == "dev" {
+		vv.PreRelease = ""
+	}
+
 	var versions semver.Versions
 	for _, r := range releases {
 		rv := mustToSemver(r.GetName())
@@ -123,6 +127,10 @@ func mustFindLatestMajor(version string, releases []v1alpha1.Release) v1alpha1.R
 
 func mustFindPreviousMajor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
+
+	if vv.PreRelease == "dev" {
+		vv.PreRelease = ""
+	}
 
 	var versions semver.Versions
 	for _, r := range releases {

--- a/pkg/release/major.go
+++ b/pkg/release/major.go
@@ -98,7 +98,7 @@ func mustFindMajors(version string, releases []v1alpha1.Release) (v1alpha1.Relea
 func mustFindLatestMajor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
 
-	if vv.PreRelease == "dev" {
+	if vv.PreRelease == devSuffix {
 		vv.PreRelease = ""
 	}
 
@@ -128,7 +128,7 @@ func mustFindLatestMajor(version string, releases []v1alpha1.Release) v1alpha1.R
 func mustFindPreviousMajor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
 
-	if vv.PreRelease == "dev" {
+	if vv.PreRelease == devSuffix {
 		vv.PreRelease = ""
 	}
 

--- a/pkg/release/major_test.go
+++ b/pkg/release/major_test.go
@@ -113,7 +113,7 @@ func Test_Release_mustFindMajor(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "v11.1.1-dev"}},
 			},
 			expectedPrevious: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v11.1.1-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v11.0.5"},
 			},
 			expectedLatest:     v1alpha1.Release{},
 			expectedUpgradable: false,
@@ -132,10 +132,10 @@ func Test_Release_mustFindMajor(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1"}},
 			},
 			expectedPrevious: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v11.2.3-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v11.0.0"},
 			},
 			expectedLatest: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.1.3-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1"},
 			},
 			expectedUpgradable: true,
 		},
@@ -159,6 +159,22 @@ func Test_Release_mustFindMajor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "v100.0.3-xh3b4sd"},
 			},
 			expectedUpgradable: true,
+		},
+		{
+			name:    "case 9",
+			version: "v12.1.1-dev",
+			releases: []v1alpha1.Release{
+				{ObjectMeta: metav1.ObjectMeta{Name: "v11.0.0"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v11.0.0"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v11.0.2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v11.0.5"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v11.1.1"}},
+			},
+			expectedPrevious: v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{Name: "v11.1.1"},
+			},
+			expectedLatest:     v1alpha1.Release{},
+			expectedUpgradable: false,
 		},
 	}
 

--- a/pkg/release/minor.go
+++ b/pkg/release/minor.go
@@ -98,7 +98,7 @@ func mustFindMinors(version string, releases []v1alpha1.Release) (v1alpha1.Relea
 func mustFindLatestMinor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
 
-	if vv.PreRelease == "dev" {
+	if vv.PreRelease == devSuffix {
 		vv.PreRelease = ""
 	}
 
@@ -128,7 +128,7 @@ func mustFindLatestMinor(version string, releases []v1alpha1.Release) v1alpha1.R
 func mustFindPreviousMinor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
 
-	if vv.PreRelease == "dev" {
+	if vv.PreRelease == devSuffix {
 		vv.PreRelease = ""
 	}
 

--- a/pkg/release/minor.go
+++ b/pkg/release/minor.go
@@ -98,6 +98,10 @@ func mustFindMinors(version string, releases []v1alpha1.Release) (v1alpha1.Relea
 func mustFindLatestMinor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
 
+	if vv.PreRelease == "dev" {
+		vv.PreRelease = ""
+	}
+
 	var versions semver.Versions
 	for _, r := range releases {
 		rv := mustToSemver(r.GetName())
@@ -123,6 +127,10 @@ func mustFindLatestMinor(version string, releases []v1alpha1.Release) v1alpha1.R
 
 func mustFindPreviousMinor(version string, releases []v1alpha1.Release) v1alpha1.Release {
 	vv := mustToSemver(version)
+
+	if vv.PreRelease == "dev" {
+		vv.PreRelease = ""
+	}
 
 	var versions semver.Versions
 	for _, r := range releases {

--- a/pkg/release/minor_test.go
+++ b/pkg/release/minor_test.go
@@ -102,13 +102,11 @@ func Test_Release_mustFindMinor(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1-dev"}},
 			},
-			expectedPrevious: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.2-dev"},
-			},
+			expectedPrevious: v1alpha1.Release{},
 			expectedLatest: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"},
 			},
-			expectedUpgradable: true,
+			expectedUpgradable: false,
 		},
 		{
 			name:    "case 6",
@@ -122,7 +120,7 @@ func Test_Release_mustFindMinor(t *testing.T) {
 			},
 			expectedPrevious: v1alpha1.Release{},
 			expectedLatest: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"},
 			},
 			expectedUpgradable: false,
 		},
@@ -139,13 +137,11 @@ func Test_Release_mustFindMinor(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1"}},
 			},
-			expectedPrevious: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.1.7-dev"},
-			},
+			expectedPrevious: v1alpha1.Release{},
 			expectedLatest: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.2.3-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1"},
 			},
-			expectedUpgradable: true,
+			expectedUpgradable: false,
 		},
 		{
 			name:    "case 8",
@@ -164,6 +160,27 @@ func Test_Release_mustFindMinor(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "v100.0.3-xh3b4sd"},
 			},
 			expectedUpgradable: false,
+		},
+		{
+			name:    "case 9",
+			version: "v12.2.3-dev",
+			releases: []v1alpha1.Release{
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.0.0"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.2.0"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.7"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.3"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.2.3"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1"}},
+			},
+			expectedPrevious: v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.1.7"},
+			},
+			expectedLatest: v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.2.3"},
+			},
+			expectedUpgradable: true,
 		},
 	}
 

--- a/pkg/release/patch.go
+++ b/pkg/release/patch.go
@@ -94,7 +94,7 @@ func (p *Patch) Version() VersionContainer {
 func mustFindPatches(version string, releases []v1alpha1.Release) (v1alpha1.Release, v1alpha1.Release) {
 	vv := mustToSemver(version)
 
-	if vv.PreRelease == "dev" {
+	if vv.PreRelease == devSuffix {
 		vv.PreRelease = ""
 	}
 

--- a/pkg/release/patch.go
+++ b/pkg/release/patch.go
@@ -94,6 +94,10 @@ func (p *Patch) Version() VersionContainer {
 func mustFindPatches(version string, releases []v1alpha1.Release) (v1alpha1.Release, v1alpha1.Release) {
 	vv := mustToSemver(version)
 
+	if vv.PreRelease == "dev" {
+		vv.PreRelease = ""
+	}
+
 	var versions semver.Versions
 	for _, r := range releases {
 		rv := mustToSemver(r.GetName())

--- a/pkg/release/patch_test.go
+++ b/pkg/release/patch_test.go
@@ -103,11 +103,13 @@ func Test_Release_mustFindPatch(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1"}},
 			},
-			expectedPrevious: v1alpha1.Release{},
-			expectedLatest: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.0-dev"},
+			expectedPrevious: v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.0"},
 			},
-			expectedUpgradable: false,
+			expectedLatest: v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"},
+			},
+			expectedUpgradable: true,
 		},
 		{
 			name:    "case 6",
@@ -121,10 +123,10 @@ func Test_Release_mustFindPatch(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "v12.1.1"}},
 			},
 			expectedPrevious: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.0-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.0"},
 			},
 			expectedLatest: v1alpha1.Release{
-				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.3-dev"},
+				ObjectMeta: metav1.ObjectMeta{Name: "v12.0.5"},
 			},
 			expectedUpgradable: true,
 		},

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -8,6 +8,10 @@ import (
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
 )
 
+const (
+	devSuffix = "dev"
+)
+
 func mustToSemver(s string) *semver.Version {
 	v, err := semver.NewVersion(strings.Replace(s, "v", "", 1))
 	if err != nil {


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

I noticed I just broke cluster creation with my last pull request. Background is the magic release resolver tries to figure out which is the right release version to use given certain circumstances. And this shit is way too complicated. With this PR the cluster creation is fine, though I do not like the code much. With `awscnfm` having project version `12.1.2-dev` and having release version `v12.1.4` as latest release on the control plane the cluster got created like shown below. 

```
$ gsctl list clusters
ID      ORGANIZATION   NAME                          RELEASE   CREATED
...
pyev0   giantswarm     awscnfm cl001 ac001 explain   12.1.4    2020 Sep 04, 08:25 UTC
```