### PR TITLE
implement cluster upgrade action in ac003

### DIFF
--- a/pkg/action/cl002/ac001/crs.go
+++ b/pkg/action/cl002/ac001/crs.go
@@ -36,8 +36,8 @@ func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, erro
 			Description:       explainerCommand,
 			Owner:             key.Organization,
 			Region:            key.RegionFromHost(host),
-			ReleaseComponents: p.Components().Latest(),
-			ReleaseVersion:    p.Version().Latest(),
+			ReleaseComponents: p.Components().Previous(),
+			ReleaseVersion:    p.Version().Previous(),
 		}
 
 		crs, err = v1alpha2.NewClusterCRs(c)

--- a/pkg/action/cl002/ac001/explainer.go
+++ b/pkg/action/cl002/ac001/explainer.go
@@ -68,7 +68,8 @@ func (e *Explainer) explain(ctx context.Context) (string, error) {
 	}
 
 	s := `
-Create a basic Tenant Cluster with all its defaults. Note that some
+Create a basic Tenant Cluster in the previous patch version. In later actions
+the cluster is being upgraded to the latest patch version. Note that some
 information of the output below slightly differs when executing conformance
 tests on different control planes.
 

--- a/pkg/action/cl002/ac001/explainer.go
+++ b/pkg/action/cl002/ac001/explainer.go
@@ -68,8 +68,7 @@ func (e *Explainer) explain(ctx context.Context) (string, error) {
 	}
 
 	s := `
-Create a basic Tenant Cluster in the previous patch version. In later actions
-the cluster is being upgraded to the latest patch version. Note that some
+Create a basic Tenant Cluster with all its defaults. Note that some
 information of the output below slightly differs when executing conformance
 tests on different control planes.
 

--- a/pkg/action/cl002/ac003/executor.go
+++ b/pkg/action/cl002/ac003/executor.go
@@ -2,8 +2,85 @@ package ac003
 
 import (
 	"context"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/apiextensions/v2/pkg/label"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/project"
+	"github.com/giantswarm/awscnfm/v12/pkg/release"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
+	var err error
+
+	var cpClients k8sclient.Interface
+	{
+		c := client.ControlPlaneConfig{
+			Logger: e.logger,
+		}
+
+		cpClients, err = client.NewControlPlane(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var releases []v1alpha1.Release
+	{
+		var list v1alpha1.ReleaseList
+		err := cpClients.CtrlClient().List(
+			ctx,
+			&list,
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		releases = list.Items
+	}
+
+	var p *release.Patch
+	{
+		c := release.PatchConfig{
+			FromEnv:     env.ReleaseVersion(),
+			FromProject: project.Version(),
+			Releases:    releases,
+		}
+
+		p, err = release.NewPatch(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var cl apiv1alpha2.Cluster
+	{
+		err = cpClients.CtrlClient().Get(
+			ctx,
+			types.NamespacedName{Name: e.tenantCluster, Namespace: v1.NamespaceDefault},
+			&cl,
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	cl.Labels[label.ClusterOperatorVersion] = p.Components().Latest()["cluster-operator"]
+	cl.Labels[label.ReleaseVersion] = p.Version().Latest()
+
+	{
+		err = cpClients.CtrlClient().Update(ctx, &cl)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/action/cl002/ac003/explainer.go
+++ b/pkg/action/cl002/ac003/explainer.go
@@ -5,5 +5,15 @@ import (
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	return "", nil
+	s := `
+Upgrade the Tenant Cluster to the latest patch version.
+
+	* Fetch the Cluster CR.
+	* Set the desired cluster-operator version in the CR labels.
+	* Set the desired release version in the CR labels.
+	* Update the Cluster CR in the Control Plane.
+
+	`
+
+	return s, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

This implements triggering the cluster upgrade. The next step would be to implement an action that waits for the upgrade to complete. 

```
$ awscnfm cl002 ac003 explain
Upgrade the Tenant Cluster to the latest patch version.

	* Fetch the Cluster CR.
	* Set the desired cluster-operator version in the CR labels.
	* Set the desired release version in the CR labels.
	* Update the Cluster CR in the Control Plane.

```