### PR TITLE
check cluster upgrade successfully finished

### DIFF
--- a/pkg/action/cl002/ac004/error.go
+++ b/pkg/action/cl002/ac004/error.go
@@ -1,0 +1,13 @@
+package ac004
+
+import "github.com/giantswarm/microerror"
+
+var wrongClusterStatusConditionError = &microerror.Error{
+	Kind: "wrongClusterStatusConditionError",
+	Desc: "We want to see the 'Updated' cluster status condition in order to verify that the Tenant Cluster upgrade was finished successfully.",
+}
+
+// IswrongClusterStatusCondition asserts wrongClusterStatusConditionError.
+func IswrongClusterStatusCondition(err error) bool {
+	return microerror.Cause(err) == wrongClusterStatusConditionError
+}

--- a/pkg/action/cl002/ac004/executor.go
+++ b/pkg/action/cl002/ac004/executor.go
@@ -2,8 +2,46 @@ package ac004
 
 import (
 	"context"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
-	return nil
+	var err error
+
+	var cpClients k8sclient.Interface
+	{
+		c := client.ControlPlaneConfig{
+			Logger: e.logger,
+		}
+
+		cpClients, err = client.NewControlPlane(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var cl v1alpha2.AWSCluster
+	{
+		err = cpClients.CtrlClient().Get(
+			ctx,
+			types.NamespacedName{Name: e.tenantCluster, Namespace: v1.NamespaceDefault},
+			&cl,
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	if cl.Status.Cluster.LatestCondition() == v1alpha2.ClusterStatusConditionUpdated {
+		return nil
+	}
+
+	return microerror.Maskf(wrongClusterStatusConditionError, cl.Status.Cluster.LatestCondition())
 }

--- a/pkg/action/cl002/ac004/explainer.go
+++ b/pkg/action/cl002/ac004/explainer.go
@@ -5,5 +5,18 @@ import (
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	return "", nil
+	s := `
+Check if the Tenant Cluster got successfully upgraded. Note that this
+particular action is not meant to be reliably used for different purposes
+than for the plan exection of cluster scope cl002. Executing this action
+against a Tenant Cluster that got already upgraded may lead to wrong results
+in case you want to assert an additional Tenant Cluster upgrade.
+
+	* Fetch the AWSCluster CR.
+	* Check if the latest cluster status condition is "Updated".
+	* Return an error if we see other cluster status conditions than "Updated".
+
+	`
+
+	return s, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.


## Context 

Adding the business logic to ac004 in order to check for a successful cluster upgrade. I tested the negative result against a created Tenant Cluster that did not get upgraded so far. 

```
$ awscnfm cl002 ac004 explain
Check if the Tenant Cluster got successfully upgraded. Note that this
particular action is not meant to be reliably used for different purposes
than for the plan exection of cluster scope cl002. Executing this action
against a Tenant Cluster that got already upgraded may lead to wrong results
in case you want to assert an additional Tenant Cluster upgrade.

	* Fetch the AWSCluster CR.
	* Check if the latest cluster status condition is "Updated".
	* Return an error if we see other cluster status conditions than "Updated".

```

```
$ awscnfm cl002 ac004 execute
Wrong Cluster Status Condition Error: Created

    We want to see the 'Updated' cluster status condition in order to verify that the Tenant Cluster upgrade was finnished successfully.

```
