### PR TITLE
configure activation logger for ignoring debug logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -36,13 +35,26 @@ func mainE(ctx context.Context) error {
 
 	var logger micrologger.Logger
 	{
-		c := micrologger.Config{
-			IOWriter: ioutil.Discard,
-		}
+		c := micrologger.Config{}
 
 		logger, err = micrologger.New(c)
 		if err != nil {
 			return microerror.Mask(err)
+		}
+	}
+
+	{
+		c := micrologger.ActivationLoggerConfig{
+			Underlying: logger,
+
+			Activations: map[string]interface{}{
+				micrologger.KeyLevel: "info",
+			},
+		}
+
+		logger, err = micrologger.NewActivation(c)
+		if err != nil {
+			panic(err)
 		}
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Our conformance test tool was silent so far. With this PR we enable info logging, which proves quite useful when executing the test plan of a given cluster scope. Earlier when activating logging a whole lot of debug logs spammed the terminal while waiting for the test actions to succeed eventually. This is cleaner now. The `micrologger` work recently been done were towards the feedback improvements here. 

```
$ awscnfm cl002 ac000 execute
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac001`","time":"2020-09-16T13:29:17.124131+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac002`","time":"2020-09-16T13:29:19.754303+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac003`","time":"2020-09-16T13:53:58.211+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac004`","time":"2020-09-16T13:53:58.610546+00:00"}
...
```