### PR TITLE
default control plane kube config

### DIFF
--- a/pkg/action/cl001/ac001/executor.go
+++ b/pkg/action/cl001/ac001/executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Executor) execute(ctx context.Context) (v1alpha2.ClusterCRs, error) {
@@ -18,6 +19,8 @@ func (e *Executor) execute(ctx context.Context) (v1alpha2.ClusterCRs, error) {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl001/ac001/explainer.go
+++ b/pkg/action/cl001/ac001/explainer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
@@ -20,6 +21,8 @@ func (e *Explainer) explain(ctx context.Context) (string, error) {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: microloggertest.New(),
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl001/ac002/executor.go
+++ b/pkg/action/cl001/ac002/executor.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
@@ -20,6 +21,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl001/ac003/executor.go
+++ b/pkg/action/cl001/ac003/executor.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -21,6 +22,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := pkgclient.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = pkgclient.NewControlPlane(c)

--- a/pkg/action/cl001/ac004/executor.go
+++ b/pkg/action/cl001/ac004/executor.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -21,6 +22,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := pkgclient.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = pkgclient.NewControlPlane(c)

--- a/pkg/action/cl001/ac005/executor.go
+++ b/pkg/action/cl001/ac005/executor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
@@ -17,6 +18,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl001/ac005/explainer.go
+++ b/pkg/action/cl001/ac005/explainer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
@@ -20,6 +21,8 @@ func (e *Explainer) explain(ctx context.Context) (string, error) {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: microloggertest.New(),
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl001/ac006/executor.go
+++ b/pkg/action/cl001/ac006/executor.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -24,6 +25,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl001/ac007/executor.go
+++ b/pkg/action/cl001/ac007/executor.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -24,6 +25,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl001/ac008/executor.go
+++ b/pkg/action/cl001/ac008/executor.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -21,6 +22,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := pkgclient.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = pkgclient.NewControlPlane(c)

--- a/pkg/action/cl001/ac009/executor.go
+++ b/pkg/action/cl001/ac009/executor.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -20,6 +21,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := pkgclient.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = pkgclient.NewControlPlane(c)

--- a/pkg/action/cl002/ac001/executor.go
+++ b/pkg/action/cl002/ac001/executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Executor) execute(ctx context.Context) (v1alpha2.ClusterCRs, error) {
@@ -18,6 +19,8 @@ func (e *Executor) execute(ctx context.Context) (v1alpha2.ClusterCRs, error) {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl002/ac001/explainer.go
+++ b/pkg/action/cl002/ac001/explainer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
@@ -20,6 +21,8 @@ func (e *Explainer) explain(ctx context.Context) (string, error) {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: microloggertest.New(),
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl002/ac002/executor.go
+++ b/pkg/action/cl002/ac002/executor.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
@@ -20,6 +21,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl002/ac003/executor.go
+++ b/pkg/action/cl002/ac003/executor.go
@@ -24,6 +24,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl002/ac004/executor.go
+++ b/pkg/action/cl002/ac004/executor.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
@@ -19,6 +20,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := client.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = client.NewControlPlane(c)

--- a/pkg/action/cl002/ac005/executor.go
+++ b/pkg/action/cl002/ac005/executor.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -21,6 +22,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := pkgclient.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = pkgclient.NewControlPlane(c)

--- a/pkg/action/cl002/ac006/executor.go
+++ b/pkg/action/cl002/ac006/executor.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkgclient "github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
 	"github.com/giantswarm/awscnfm/v12/pkg/label"
 )
 
@@ -20,6 +21,8 @@ func (e *Executor) execute(ctx context.Context) error {
 	{
 		c := pkgclient.ControlPlaneConfig{
 			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
 		}
 
 		cpClients, err = pkgclient.NewControlPlane(c)

--- a/pkg/client/control_plane.go
+++ b/pkg/client/control_plane.go
@@ -13,11 +13,17 @@ import (
 
 type ControlPlaneConfig struct {
 	Logger micrologger.Logger
+
+	KubeConfig string
 }
 
 func NewControlPlane(config ControlPlaneConfig) (k8sclient.Interface, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.KubeConfig == "" {
+		config.KubeConfig = env.DefaultKubeConfig
 	}
 
 	var err error
@@ -32,7 +38,7 @@ func NewControlPlane(config ControlPlaneConfig) (k8sclient.Interface, error) {
 			},
 			Logger: config.Logger,
 
-			KubeConfigPath: env.KubeConfig(),
+			KubeConfigPath: config.KubeConfig,
 		}
 
 		clients, err = k8sclient.NewClients(c)

--- a/pkg/env/awscnfm_kubeconfig.go
+++ b/pkg/env/awscnfm_kubeconfig.go
@@ -8,6 +8,10 @@ const (
 	EnvVarKubeConfig = "AWSCNFM_KUBECONFIG"
 )
 
+const (
+	DefaultKubeConfig = "~/.kube/config"
+)
+
 // KubeConfig is the local path to the kube config file used to create the
 // Control Plane specific rest config.
 func KubeConfig() string {


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

When running tests locally now you do not have to set the environment variable for the Control Plane kube config anymore. It is defaulted to the default location. 