### PR TITLE
generate commands for cl003

### DIFF
--- a/cmd/cl003/ac000/execute/zz_generated.command.go
+++ b/cmd/cl003/ac000/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac000 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac000/execute/zz_generated.error.go
+++ b/cmd/cl003/ac000/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac000/execute/zz_generated.flag.go
+++ b/cmd/cl003/ac000/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac000/execute/zz_generated.runner.go
+++ b/cmd/cl003/ac000/execute/zz_generated.runner.go
@@ -1,0 +1,65 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac000"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Executor
+	{
+		c := ac000.ExecutorConfig{
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac000.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac000/explain/zz_generated.command.go
+++ b/cmd/cl003/ac000/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac000 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac000/explain/zz_generated.error.go
+++ b/cmd/cl003/ac000/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac000/explain/zz_generated.flag.go
+++ b/cmd/cl003/ac000/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac000/explain/zz_generated.runner.go
+++ b/cmd/cl003/ac000/explain/zz_generated.runner.go
@@ -1,0 +1,67 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac000"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac000.ExplainerConfig{
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac000.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl003/ac000/zz_generated.command.go
+++ b/cmd/cl003/ac000/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac000
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac000/execute"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac000/explain"
+)
+
+const (
+	name        = "ac000"
+	description = "Action ac000 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl003/ac000/zz_generated.error.go
+++ b/cmd/cl003/ac000/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac000
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac000/zz_generated.flag.go
+++ b/cmd/cl003/ac000/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac000
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac000/zz_generated.runner.go
+++ b/cmd/cl003/ac000/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac000
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac001/execute/zz_generated.command.go
+++ b/cmd/cl003/ac001/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac001 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac001/execute/zz_generated.error.go
+++ b/cmd/cl003/ac001/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac001/execute/zz_generated.flag.go
+++ b/cmd/cl003/ac001/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac001/execute/zz_generated.runner.go
+++ b/cmd/cl003/ac001/execute/zz_generated.runner.go
@@ -1,0 +1,65 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac001"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Executor
+	{
+		c := ac001.ExecutorConfig{
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac001.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac001/explain/zz_generated.command.go
+++ b/cmd/cl003/ac001/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac001 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac001/explain/zz_generated.error.go
+++ b/cmd/cl003/ac001/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac001/explain/zz_generated.flag.go
+++ b/cmd/cl003/ac001/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac001/explain/zz_generated.runner.go
+++ b/cmd/cl003/ac001/explain/zz_generated.runner.go
@@ -1,0 +1,67 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac001"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac001.ExplainerConfig{
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac001.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl003/ac001/zz_generated.command.go
+++ b/cmd/cl003/ac001/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac001
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac001/execute"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac001/explain"
+)
+
+const (
+	name        = "ac001"
+	description = "Action ac001 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl003/ac001/zz_generated.error.go
+++ b/cmd/cl003/ac001/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac001
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac001/zz_generated.flag.go
+++ b/cmd/cl003/ac001/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac001
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac001/zz_generated.runner.go
+++ b/cmd/cl003/ac001/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac001
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac002/execute/zz_generated.command.go
+++ b/cmd/cl003/ac002/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac002 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac002/execute/zz_generated.error.go
+++ b/cmd/cl003/ac002/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac002/execute/zz_generated.flag.go
+++ b/cmd/cl003/ac002/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac002/execute/zz_generated.runner.go
+++ b/cmd/cl003/ac002/execute/zz_generated.runner.go
@@ -1,0 +1,65 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac002"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Executor
+	{
+		c := ac002.ExecutorConfig{
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac002.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac002/explain/zz_generated.command.go
+++ b/cmd/cl003/ac002/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac002 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac002/explain/zz_generated.error.go
+++ b/cmd/cl003/ac002/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac002/explain/zz_generated.flag.go
+++ b/cmd/cl003/ac002/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac002/explain/zz_generated.runner.go
+++ b/cmd/cl003/ac002/explain/zz_generated.runner.go
@@ -1,0 +1,67 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac002"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac002.ExplainerConfig{
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac002.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl003/ac002/zz_generated.command.go
+++ b/cmd/cl003/ac002/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac002
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac002/execute"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac002/explain"
+)
+
+const (
+	name        = "ac002"
+	description = "Action ac002 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl003/ac002/zz_generated.error.go
+++ b/cmd/cl003/ac002/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac002
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac002/zz_generated.flag.go
+++ b/cmd/cl003/ac002/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac002
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac002/zz_generated.runner.go
+++ b/cmd/cl003/ac002/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac002
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac003/execute/zz_generated.command.go
+++ b/cmd/cl003/ac003/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac003 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac003/execute/zz_generated.error.go
+++ b/cmd/cl003/ac003/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac003/execute/zz_generated.flag.go
+++ b/cmd/cl003/ac003/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac003/execute/zz_generated.runner.go
+++ b/cmd/cl003/ac003/execute/zz_generated.runner.go
@@ -1,0 +1,65 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac003"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Executor
+	{
+		c := ac003.ExecutorConfig{
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac003.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac003/explain/zz_generated.command.go
+++ b/cmd/cl003/ac003/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac003 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac003/explain/zz_generated.error.go
+++ b/cmd/cl003/ac003/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac003/explain/zz_generated.flag.go
+++ b/cmd/cl003/ac003/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac003/explain/zz_generated.runner.go
+++ b/cmd/cl003/ac003/explain/zz_generated.runner.go
@@ -1,0 +1,67 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac003"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac003.ExplainerConfig{
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac003.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl003/ac003/zz_generated.command.go
+++ b/cmd/cl003/ac003/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac003
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac003/execute"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac003/explain"
+)
+
+const (
+	name        = "ac003"
+	description = "Action ac003 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl003/ac003/zz_generated.error.go
+++ b/cmd/cl003/ac003/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac003
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac003/zz_generated.flag.go
+++ b/cmd/cl003/ac003/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac003
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac003/zz_generated.runner.go
+++ b/cmd/cl003/ac003/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac003
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac004/execute/zz_generated.command.go
+++ b/cmd/cl003/ac004/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac004 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac004/execute/zz_generated.error.go
+++ b/cmd/cl003/ac004/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac004/execute/zz_generated.flag.go
+++ b/cmd/cl003/ac004/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac004/execute/zz_generated.runner.go
+++ b/cmd/cl003/ac004/execute/zz_generated.runner.go
@@ -1,0 +1,65 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac004"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Executor
+	{
+		c := ac004.ExecutorConfig{
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac004.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac004/explain/zz_generated.command.go
+++ b/cmd/cl003/ac004/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac004 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac004/explain/zz_generated.error.go
+++ b/cmd/cl003/ac004/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac004/explain/zz_generated.flag.go
+++ b/cmd/cl003/ac004/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac004/explain/zz_generated.runner.go
+++ b/cmd/cl003/ac004/explain/zz_generated.runner.go
@@ -1,0 +1,67 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac004"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac004.ExplainerConfig{
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac004.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl003/ac004/zz_generated.command.go
+++ b/cmd/cl003/ac004/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac004
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac004/execute"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac004/explain"
+)
+
+const (
+	name        = "ac004"
+	description = "Action ac004 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl003/ac004/zz_generated.error.go
+++ b/cmd/cl003/ac004/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac004
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac004/zz_generated.flag.go
+++ b/cmd/cl003/ac004/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac004
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac004/zz_generated.runner.go
+++ b/cmd/cl003/ac004/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac004
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac005/execute/zz_generated.command.go
+++ b/cmd/cl003/ac005/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac005 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac005/execute/zz_generated.error.go
+++ b/cmd/cl003/ac005/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac005/execute/zz_generated.flag.go
+++ b/cmd/cl003/ac005/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac005/execute/zz_generated.runner.go
+++ b/cmd/cl003/ac005/execute/zz_generated.runner.go
@@ -1,0 +1,65 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac005"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Executor
+	{
+		c := ac005.ExecutorConfig{
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac005.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac005/explain/zz_generated.command.go
+++ b/cmd/cl003/ac005/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac005 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac005/explain/zz_generated.error.go
+++ b/cmd/cl003/ac005/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac005/explain/zz_generated.flag.go
+++ b/cmd/cl003/ac005/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac005/explain/zz_generated.runner.go
+++ b/cmd/cl003/ac005/explain/zz_generated.runner.go
@@ -1,0 +1,67 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac005"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac005.ExplainerConfig{
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac005.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl003/ac005/zz_generated.command.go
+++ b/cmd/cl003/ac005/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac005
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac005/execute"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac005/explain"
+)
+
+const (
+	name        = "ac005"
+	description = "Action ac005 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl003/ac005/zz_generated.error.go
+++ b/cmd/cl003/ac005/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac005
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac005/zz_generated.flag.go
+++ b/cmd/cl003/ac005/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac005
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac005/zz_generated.runner.go
+++ b/cmd/cl003/ac005/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac005
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac006/execute/zz_generated.command.go
+++ b/cmd/cl003/ac006/execute/zz_generated.command.go
@@ -1,0 +1,53 @@
+package execute
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "execute"
+	description = "Execute action ac006 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac006/execute/zz_generated.error.go
+++ b/cmd/cl003/ac006/execute/zz_generated.error.go
@@ -1,0 +1,21 @@
+package execute
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac006/execute/zz_generated.flag.go
+++ b/cmd/cl003/ac006/execute/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package execute
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac006/execute/zz_generated.runner.go
+++ b/cmd/cl003/ac006/execute/zz_generated.runner.go
@@ -1,0 +1,65 @@
+package execute
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac006"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Executor
+	{
+		c := ac006.ExecutorConfig{
+			Command: cmd,
+			Logger:  r.logger,
+
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac006.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/ac006/explain/zz_generated.command.go
+++ b/cmd/cl003/ac006/explain/zz_generated.command.go
@@ -1,0 +1,53 @@
+package explain
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "explain"
+	description = "Explain action ac006 for cluster cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cl003/ac006/explain/zz_generated.error.go
+++ b/cmd/cl003/ac006/explain/zz_generated.error.go
@@ -1,0 +1,21 @@
+package explain
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac006/explain/zz_generated.flag.go
+++ b/cmd/cl003/ac006/explain/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package explain
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac006/explain/zz_generated.runner.go
+++ b/cmd/cl003/ac006/explain/zz_generated.runner.go
@@ -1,0 +1,67 @@
+package explain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/action"
+	"github.com/giantswarm/awscnfm/v12/pkg/action/cl003/ac006"
+	"github.com/giantswarm/awscnfm/v12/pkg/config"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var e action.Explainer
+	{
+		c := ac006.ExplainerConfig{
+			Scope:         "cl003",
+			TenantCluster: config.Cluster("cl003", env.TenantCluster()),
+		}
+
+		e, err = ac006.NewExplainer(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s, err := e.Explain(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Println(strings.TrimSpace(s))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/cl003/ac006/zz_generated.command.go
+++ b/cmd/cl003/ac006/zz_generated.command.go
@@ -1,0 +1,89 @@
+package ac006
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac006/execute"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac006/explain"
+)
+
+const (
+	name        = "ac006"
+	description = "Action ac006 for cluster 001."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var executeCmd *cobra.Command
+	{
+		c := execute.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		executeCmd, err = execute.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var explainCmd *cobra.Command
+	{
+		c := explain.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		explainCmd, err = explain.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(executeCmd)
+	c.AddCommand(explainCmd)
+
+	return c, nil
+}

--- a/cmd/cl003/ac006/zz_generated.error.go
+++ b/cmd/cl003/ac006/zz_generated.error.go
@@ -1,0 +1,21 @@
+package ac006
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/ac006/zz_generated.flag.go
+++ b/cmd/cl003/ac006/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package ac006
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/ac006/zz_generated.runner.go
+++ b/cmd/cl003/ac006/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package ac006
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/cl003/zz_generated.command.go
+++ b/cmd/cl003/zz_generated.command.go
@@ -1,0 +1,169 @@
+package cl003
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac000"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac001"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac002"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac003"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac004"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac005"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003/ac006"
+)
+
+const (
+	name        = "cl003"
+	description = "Conformance tests for cluster scope cl003."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var ac000Cmd *cobra.Command
+	{
+		c := ac000.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac000Cmd, err = ac000.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ac001Cmd *cobra.Command
+	{
+		c := ac001.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac001Cmd, err = ac001.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ac002Cmd *cobra.Command
+	{
+		c := ac002.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac002Cmd, err = ac002.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ac003Cmd *cobra.Command
+	{
+		c := ac003.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac003Cmd, err = ac003.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ac004Cmd *cobra.Command
+	{
+		c := ac004.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac004Cmd, err = ac004.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ac005Cmd *cobra.Command
+	{
+		c := ac005.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac005Cmd, err = ac005.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ac006Cmd *cobra.Command
+	{
+		c := ac006.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		ac006Cmd, err = ac006.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(ac000Cmd)
+	c.AddCommand(ac001Cmd)
+	c.AddCommand(ac002Cmd)
+	c.AddCommand(ac003Cmd)
+	c.AddCommand(ac004Cmd)
+	c.AddCommand(ac005Cmd)
+	c.AddCommand(ac006Cmd)
+
+	return c, nil
+}

--- a/cmd/cl003/zz_generated.error.go
+++ b/cmd/cl003/zz_generated.error.go
@@ -1,0 +1,21 @@
+package cl003
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/cl003/zz_generated.flag.go
+++ b/cmd/cl003/zz_generated.flag.go
@@ -1,0 +1,13 @@
+package cl003
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/cl003/zz_generated.runner.go
+++ b/cmd/cl003/zz_generated.runner.go
@@ -1,0 +1,42 @@
+package cl003
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/cmd/cl001"
 	"github.com/giantswarm/awscnfm/v12/cmd/cl002"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl003"
 	"github.com/giantswarm/awscnfm/v12/cmd/completion"
 	"github.com/giantswarm/awscnfm/v12/cmd/generate"
 	"github.com/giantswarm/awscnfm/v12/cmd/insert"
@@ -94,6 +95,20 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var cl003Cmd *cobra.Command
+	{
+		c := cl003.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		cl003Cmd, err = cl003.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var completionCmd *cobra.Command
 	{
 		c := completion.Config{
@@ -157,6 +172,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	m.AddCommand(cl001Cmd)
 	m.AddCommand(cl002Cmd)
+	m.AddCommand(cl003Cmd)
 	m.AddCommand(completionCmd)
 	m.AddCommand(generateCmd)
 	m.AddCommand(insertCmd)

--- a/pkg/action/cl003/ac001/zz_generated.executor.go
+++ b/pkg/action/cl003/ac001/zz_generated.executor.go
@@ -51,7 +51,7 @@ func (e *Executor) Execute(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
-	config.SetCluster("cl002", crs.Cluster.GetName())
+	config.SetCluster("cl003", crs.Cluster.GetName())
 
 	return nil
 }

--- a/pkg/action/cl003/ac001/zz_generated.explainer.go
+++ b/pkg/action/cl003/ac001/zz_generated.explainer.go
@@ -10,7 +10,7 @@ const (
 	// explainerCommand is for internal documentation purposes only so that
 	// commands can self describe and explain themselves better. This
 	// information might be used in different creative ways.
-	explainerCommand = "awscnfm cl002 ac001 explain"
+	explainerCommand = "awscnfm cl003 ac001 explain"
 )
 
 const (


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

This is all generated code to wire the action commands for the new cluster scope `cl003`. 