### PR TITLE
ensure a minor release upgrade in cluster scope cl003

### DIFF
--- a/pkg/action/cl003/ac001/crs.go
+++ b/pkg/action/cl003/ac001/crs.go
@@ -14,15 +14,15 @@ import (
 func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, error) {
 	var err error
 
-	var p *release.Patch
+	var m *release.Minor
 	{
-		c := release.PatchConfig{
+		c := release.MinorConfig{
 			FromEnv:     env.ReleaseVersion(),
 			FromProject: project.Version(),
 			Releases:    releases,
 		}
 
-		p, err = release.NewPatch(c)
+		m, err = release.NewMinor(c)
 		if err != nil {
 			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
 		}
@@ -36,8 +36,8 @@ func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, erro
 			Description:       explainerCommand,
 			Owner:             key.Organization,
 			Region:            key.RegionFromHost(host),
-			ReleaseComponents: p.Components().Previous(),
-			ReleaseVersion:    p.Version().Previous(),
+			ReleaseComponents: m.Components().Previous(),
+			ReleaseVersion:    m.Version().Previous(),
 		}
 
 		crs, err = v1alpha2.NewClusterCRs(c)

--- a/pkg/action/cl003/ac003/executor.go
+++ b/pkg/action/cl003/ac003/executor.go
@@ -48,15 +48,15 @@ func (e *Executor) execute(ctx context.Context) error {
 		releases = list.Items
 	}
 
-	var p *release.Patch
+	var m *release.Minor
 	{
-		c := release.PatchConfig{
+		c := release.MinorConfig{
 			FromEnv:     env.ReleaseVersion(),
 			FromProject: project.Version(),
 			Releases:    releases,
 		}
 
-		p, err = release.NewPatch(c)
+		m, err = release.NewMinor(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -74,8 +74,8 @@ func (e *Executor) execute(ctx context.Context) error {
 		}
 	}
 
-	cl.Labels[label.ClusterOperatorVersion] = p.Components().Latest()["cluster-operator"]
-	cl.Labels[label.ReleaseVersion] = p.Version().Latest()
+	cl.Labels[label.ClusterOperatorVersion] = m.Components().Latest()["cluster-operator"]
+	cl.Labels[label.ReleaseVersion] = m.Version().Latest()
 
 	{
 		err = cpClients.CtrlClient().Update(ctx, &cl)

--- a/pkg/action/cl003/ac003/explainer.go
+++ b/pkg/action/cl003/ac003/explainer.go
@@ -6,7 +6,7 @@ import (
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
 	s := `
-Upgrade the Tenant Cluster to the latest patch version.
+Upgrade the Tenant Cluster to the latest minor version.
 
 	* Fetch the Cluster CR.
 	* Set the desired cluster-operator version in the CR labels.


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Since the cluster scopes are mostly self sufficient and we have a bit of duplicated code by design we simply run the minor upgrade test like the patch upgrade test. In this PR the minor version change is ensured according to the release resolver implementation we prepared some time ago. 