### PR TITLE
implement-ac011-kiam-clean-resources

### DIFF
--- a/pkg/action/cl001/ac011/executor.go
+++ b/pkg/action/cl001/ac011/executor.go
@@ -2,13 +2,15 @@ package ac011
 
 import (
 	"context"
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
-	"github.com/giantswarm/awscnfm/v12/pkg/key"
+
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
 )
 
 func (e *Executor) execute(ctx context.Context) error {

--- a/pkg/action/cl001/ac011/executor.go
+++ b/pkg/action/cl001/ac011/executor.go
@@ -2,8 +2,66 @@ package ac011
 
 import (
 	"context"
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func (e *Executor) execute(ctx context.Context) error {
+	var err error
+
+	var cpClients k8sclient.Interface
+	{
+		c := client.ControlPlaneConfig{
+			Logger: e.logger,
+
+			KubeConfig: env.KubeConfig(),
+		}
+
+		cpClients, err = client.NewControlPlane(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var tcClients k8sclient.Interface
+	{
+		c := client.TenantClusterConfig{
+			ControlPlane: cpClients,
+			Logger:       e.logger,
+
+			Scope: e.scope,
+		}
+
+		tcClients, err = client.NewTenantCluster(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = e.cleanupKiamTestResources(ctx, tcClients.K8sClient())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// cleanupKiamTestResources will cleanup kiam test resources
+func (e *Executor) cleanupKiamTestResources(ctx context.Context, tcClient kubernetes.Interface) error {
+	err := tcClient.BatchV1().Jobs(key.KiamTestNamespace).Delete(ctx, key.KiamTestJobName(), metav1.DeleteOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = tcClient.NetworkingV1().NetworkPolicies(key.KiamTestNamespace).Delete(ctx, key.KiamTestNetPolName(), metav1.DeleteOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }

--- a/pkg/action/cl001/ac011/explainer.go
+++ b/pkg/action/cl001/ac011/explainer.go
@@ -5,5 +5,6 @@ import (
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	return "", nil
+	s := `Cleanup kiam test resources from the tenant cluster`
+	return s, nil
 }

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+	"github.com/giantswarm/awscnfm/v12/pkg/project"
 	"strings"
 )
 
@@ -21,6 +22,10 @@ const (
 	Organization = "giantswarm"
 )
 
+const (
+	KiamTestNamespace = "kube-system"
+)
+
 func APIEndpoint(id string, base string) string {
 	return fmt.Sprintf("api.%s.k8s.%s", id, base)
 }
@@ -38,6 +43,14 @@ func GeneratedWithPrefix(s string) string {
 
 func HasGeneratedPrefix(s string) bool {
 	return strings.Contains(s, GeneratePrefix)
+}
+
+func KiamTestJobName() string {
+	return fmt.Sprintf("%s-kiam-test", project.Name())
+}
+
+func KiamTestNetPolName() string {
+	return fmt.Sprintf("%s-kiam-test", project.Name())
 }
 
 func RegionFromHost(h string) string {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -2,8 +2,9 @@ package key
 
 import (
 	"fmt"
-	"github.com/giantswarm/awscnfm/v12/pkg/project"
 	"strings"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/project"
 )
 
 const (


### PR DESCRIPTION

clean up kiam test resources

towards https://github.com/giantswarm/giantswarm/issues/13229
```
 #: awscnfm cl001 ac000 execute
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac001`","time":"2020-10-01T14:41:35.82286+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac002`","time":"2020-10-01T14:41:38.623513+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac003`","time":"2020-10-01T15:00:18.129059+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac004`","time":"2020-10-01T15:00:18.817162+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac005`","time":"2020-10-01T15:00:19.486544+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac004`","time":"2020-10-01T15:00:20.043236+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac006`","time":"2020-10-01T15:06:23.551829+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac007`","time":"2020-10-01T15:08:25.535299+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac008`","time":"2020-10-01T15:08:26.213276+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac009`","time":"2020-10-01T15:08:30.802902+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac010`","time":"2020-10-01T15:08:31.837811+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac011`","time":"2020-10-01T15:09:17.861738+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac012`","time":"2020-10-01T15:09:19.078739+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.3/activation_logger.go:104","level":"info","message":"executing action `ac013`","time":"2020-10-01T15:09:19.600448+00:00"
```