### PR TITLE
wire up new cluster scope cl005 for major upgrade test

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/awscnfm/v12/cmd/cl002"
 	"github.com/giantswarm/awscnfm/v12/cmd/cl003"
 	"github.com/giantswarm/awscnfm/v12/cmd/cl004"
+	"github.com/giantswarm/awscnfm/v12/cmd/cl005"
 	"github.com/giantswarm/awscnfm/v12/cmd/completion"
 	"github.com/giantswarm/awscnfm/v12/cmd/generate"
 	"github.com/giantswarm/awscnfm/v12/cmd/insert"
@@ -124,6 +125,20 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var cl005Cmd *cobra.Command
+	{
+		c := cl005.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		cl005Cmd, err = cl005.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var completionCmd *cobra.Command
 	{
 		c := completion.Config{
@@ -189,6 +204,7 @@ func New(config Config) (*cobra.Command, error) {
 	m.AddCommand(cl002Cmd)
 	m.AddCommand(cl003Cmd)
 	m.AddCommand(cl004Cmd)
+	m.AddCommand(cl005Cmd)
 	m.AddCommand(completionCmd)
 	m.AddCommand(generateCmd)
 	m.AddCommand(insertCmd)

--- a/pkg/action/cl005/ac000/explainer.go
+++ b/pkg/action/cl005/ac000/explainer.go
@@ -13,8 +13,8 @@ func (e *Explainer) explain(ctx context.Context) (string, error) {
 		d += s.Backoff.Wait()
 	}
 
-	s := "Test plan for " + e.scope + " launches a basic Tenant Cluster in the previous minor release\n"
-	s += "and upgrades the Tenant Cluster to the latest minor release once it is up. Plan\n"
+	s := "Test plan for " + e.scope + " launches a basic Tenant Cluster in the previous major release\n"
+	s += "and upgrades the Tenant Cluster to the latest major release once it is up. Plan\n"
 	s += "execution might take up to " + d.String() + ".\n\n"
 
 	t := [][]string{{"ACTION", "RETRY", "WAIT", "COMMENT"}}

--- a/pkg/action/cl005/ac001/crs.go
+++ b/pkg/action/cl005/ac001/crs.go
@@ -14,15 +14,15 @@ import (
 func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, error) {
 	var err error
 
-	var m *release.Minor
+	var m *release.Major
 	{
-		c := release.MinorConfig{
+		c := release.MajorConfig{
 			FromEnv:     env.ReleaseVersion(),
 			FromProject: project.Version(),
 			Releases:    releases,
 		}
 
-		m, err = release.NewMinor(c)
+		m, err = release.NewMajor(c)
 		if err != nil {
 			return v1alpha2.ClusterCRs{}, microerror.Mask(err)
 		}

--- a/pkg/action/cl005/ac003/executor.go
+++ b/pkg/action/cl005/ac003/executor.go
@@ -48,15 +48,15 @@ func (e *Executor) execute(ctx context.Context) error {
 		releases = list.Items
 	}
 
-	var m *release.Minor
+	var m *release.Major
 	{
-		c := release.MinorConfig{
+		c := release.MajorConfig{
 			FromEnv:     env.ReleaseVersion(),
 			FromProject: project.Version(),
 			Releases:    releases,
 		}
 
-		m, err = release.NewMinor(c)
+		m, err = release.NewMajor(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/pkg/action/cl005/ac003/explainer.go
+++ b/pkg/action/cl005/ac003/explainer.go
@@ -6,7 +6,7 @@ import (
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
 	s := `
-Upgrade the Tenant Cluster to the latest minor version.
+Upgrade the Tenant Cluster to the latest major version.
 
 	* Fetch the Cluster CR.
 	* Set the desired cluster-operator version in the CR labels.


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Towards https://github.com/giantswarm/giantswarm/issues/13460. 

```
$ awscnfm cl005 ac000 explain
Test plan for cl005 launches a basic Tenant Cluster in the previous major release
and upgrades the Tenant Cluster to the latest major release once it is up. Plan
execution might take up to 4h0m30s.

ACTION  RETRY  WAIT     COMMENT
ac001   2s     10s      create cluster CRs
ac002   3m0s   30m0s    check cluster access
ac003   2s     10s      trigger patch upgrade
ac004   10m0s  2h0m0s   check upgrade successful
ac005   2s     10s      delete cluster CRs
ac006   9m0s   1h30m0s  check CRs deleted

```