### PR TITLE
configure tenant client injection via environment

### DIFF
--- a/pkg/action/cl004/ac002/executor.go
+++ b/pkg/action/cl004/ac002/executor.go
@@ -37,7 +37,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)

--- a/pkg/action/cl004/ac003/executor.go
+++ b/pkg/action/cl004/ac003/executor.go
@@ -38,7 +38,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = pkgclient.NewTenantCluster(c)

--- a/pkg/action/cl004/ac004/executor.go
+++ b/pkg/action/cl004/ac004/executor.go
@@ -38,7 +38,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = pkgclient.NewTenantCluster(c)

--- a/pkg/action/cl004/ac006/executor.go
+++ b/pkg/action/cl004/ac006/executor.go
@@ -41,7 +41,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)

--- a/pkg/action/cl004/ac007/executor.go
+++ b/pkg/action/cl004/ac007/executor.go
@@ -41,7 +41,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)

--- a/pkg/action/cl004/ac009/executor.go
+++ b/pkg/action/cl004/ac009/executor.go
@@ -47,7 +47,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)

--- a/pkg/action/cl004/ac010/executor.go
+++ b/pkg/action/cl004/ac010/executor.go
@@ -48,7 +48,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)

--- a/pkg/action/cl004/ac011/executor.go
+++ b/pkg/action/cl004/ac011/executor.go
@@ -43,7 +43,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)

--- a/pkg/action/cl005/ac002/executor.go
+++ b/pkg/action/cl005/ac002/executor.go
@@ -37,7 +37,8 @@ func (e *Executor) execute(ctx context.Context) error {
 			ControlPlane: cpClients,
 			Logger:       e.logger,
 
-			Scope: e.scope,
+			KubeConfig: env.TenantClusterKubeConfig(),
+			Scope:      e.scope,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

I delayed merging of the tenant client injection. Meanwhile work happened that got out of sync. Just following up where configuration is missing. The design might be a bit unfortunate when things like this can happen, though I do not have a good idea to resolve it quickly yet. 