### PR TITLE
remove network dependencies from explainer

### DIFF
--- a/pkg/action/cl001/ac001/explainer.go
+++ b/pkg/action/cl001/ac001/explainer.go
@@ -2,88 +2,10 @@ package ac001
 
 import (
 	"context"
-	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger/microloggertest"
-
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	var err error
-
-	var cpClients k8sclient.Interface
-	{
-		c := client.ControlPlaneConfig{
-			Logger: microloggertest.New(),
-
-			KubeConfig: env.ControlPlaneKubeConfig(),
-		}
-
-		cpClients, err = client.NewControlPlane(c)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-	}
-
-	var releases []v1alpha1.Release
-	{
-		var list v1alpha1.ReleaseList
-		err := cpClients.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		releases = list.Items
-	}
-
-	crs, err := newCRs(releases, "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	clusterCR, err := yaml.Marshal(crs.Cluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsClusterCR, err := yaml.Marshal(crs.AWSCluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	g8sControlPlaneCR, err := yaml.Marshal(crs.G8sControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsControlPlaneCR, err := yaml.Marshal(crs.AWSControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	s := `
-Create a basic Tenant Cluster with all its defaults. Note that some
-information of the output below slightly differs when executing conformance
-tests on different control planes.
-
----
-` + strings.TrimSpace(string(clusterCR)) + `
----
-` + strings.TrimSpace(string(awsClusterCR)) + `
----
-` + strings.TrimSpace(string(g8sControlPlaneCR)) + `
----
-` + strings.TrimSpace(string(awsControlPlaneCR)) + `
-	`
+	s := "Create a basic Tenant Cluster with all its defaults."
 
 	return s, nil
 }

--- a/pkg/action/cl001/ac005/explainer.go
+++ b/pkg/action/cl001/ac005/explainer.go
@@ -2,74 +2,10 @@ package ac005
 
 import (
 	"context"
-	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger/microloggertest"
-
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	var err error
-
-	var cpClients k8sclient.Interface
-	{
-		c := client.ControlPlaneConfig{
-			Logger: microloggertest.New(),
-
-			KubeConfig: env.ControlPlaneKubeConfig(),
-		}
-
-		cpClients, err = client.NewControlPlane(c)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-	}
-
-	var releases []v1alpha1.Release
-	{
-		var list v1alpha1.ReleaseList
-		err := cpClients.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		releases = list.Items
-	}
-
-	crs, err := newCRs(ctx, releases, "al9qy", "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	machineDeploymentCR, err := yaml.Marshal(crs.MachineDeployment)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsMachineDeploymentCR, err := yaml.Marshal(crs.AWSMachineDeployment)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	s := `
-Create a basic Node Pool with all its defaults. Note that some information of
-the output below slightly differs when executing conformance tests on
-different control planes.
-
----
-` + strings.TrimSpace(string(machineDeploymentCR)) + `
----
-` + strings.TrimSpace(string(awsMachineDeploymentCR)) + `
-	`
+	s := "Create a basic Node Pool with all its defaults."
 
 	return s, nil
 }

--- a/pkg/action/cl002/ac001/explainer.go
+++ b/pkg/action/cl002/ac001/explainer.go
@@ -2,88 +2,10 @@ package ac001
 
 import (
 	"context"
-	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger/microloggertest"
-
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	var err error
-
-	var cpClients k8sclient.Interface
-	{
-		c := client.ControlPlaneConfig{
-			Logger: microloggertest.New(),
-
-			KubeConfig: env.ControlPlaneKubeConfig(),
-		}
-
-		cpClients, err = client.NewControlPlane(c)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-	}
-
-	var releases []v1alpha1.Release
-	{
-		var list v1alpha1.ReleaseList
-		err := cpClients.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		releases = list.Items
-	}
-
-	crs, err := newCRs(releases, "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	clusterCR, err := yaml.Marshal(crs.Cluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsClusterCR, err := yaml.Marshal(crs.AWSCluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	g8sControlPlaneCR, err := yaml.Marshal(crs.G8sControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsControlPlaneCR, err := yaml.Marshal(crs.AWSControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	s := `
-Create a basic Tenant Cluster with all its defaults. Note that some
-information of the output below slightly differs when executing conformance
-tests on different control planes.
-
----
-` + strings.TrimSpace(string(clusterCR)) + `
----
-` + strings.TrimSpace(string(awsClusterCR)) + `
----
-` + strings.TrimSpace(string(g8sControlPlaneCR)) + `
----
-` + strings.TrimSpace(string(awsControlPlaneCR)) + `
-	`
+	s := "Create a basic Tenant Cluster with all its defaults."
 
 	return s, nil
 }

--- a/pkg/action/cl003/ac001/explainer.go
+++ b/pkg/action/cl003/ac001/explainer.go
@@ -2,88 +2,10 @@ package ac001
 
 import (
 	"context"
-	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger/microloggertest"
-
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	var err error
-
-	var cpClients k8sclient.Interface
-	{
-		c := client.ControlPlaneConfig{
-			Logger: microloggertest.New(),
-
-			KubeConfig: env.ControlPlaneKubeConfig(),
-		}
-
-		cpClients, err = client.NewControlPlane(c)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-	}
-
-	var releases []v1alpha1.Release
-	{
-		var list v1alpha1.ReleaseList
-		err := cpClients.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		releases = list.Items
-	}
-
-	crs, err := newCRs(releases, "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	clusterCR, err := yaml.Marshal(crs.Cluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsClusterCR, err := yaml.Marshal(crs.AWSCluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	g8sControlPlaneCR, err := yaml.Marshal(crs.G8sControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsControlPlaneCR, err := yaml.Marshal(crs.AWSControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	s := `
-Create a basic Tenant Cluster with all its defaults. Note that some
-information of the output below slightly differs when executing conformance
-tests on different control planes.
-
----
-` + strings.TrimSpace(string(clusterCR)) + `
----
-` + strings.TrimSpace(string(awsClusterCR)) + `
----
-` + strings.TrimSpace(string(g8sControlPlaneCR)) + `
----
-` + strings.TrimSpace(string(awsControlPlaneCR)) + `
-	`
+	s := "Create a basic Tenant Cluster with all its defaults."
 
 	return s, nil
 }

--- a/pkg/action/cl004/ac001/explainer.go
+++ b/pkg/action/cl004/ac001/explainer.go
@@ -2,95 +2,10 @@ package ac001
 
 import (
 	"context"
-	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger/microloggertest"
-
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	var err error
-
-	var cpClients k8sclient.Interface
-	{
-		c := client.ControlPlaneConfig{
-			Logger: microloggertest.New(),
-
-			KubeConfig: env.ControlPlaneKubeConfig(),
-		}
-
-		cpClients, err = client.NewControlPlane(c)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-	}
-
-	var releases []v1alpha1.Release
-	{
-		var list v1alpha1.ReleaseList
-		err := cpClients.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		releases = list.Items
-	}
-
-	crs, npcrs, err := newCRs(releases, "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	networkPoolCR, err := yaml.Marshal(npcrs.NetworkPool)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	clusterCR, err := yaml.Marshal(crs.Cluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsClusterCR, err := yaml.Marshal(crs.AWSCluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	g8sControlPlaneCR, err := yaml.Marshal(crs.G8sControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsControlPlaneCR, err := yaml.Marshal(crs.AWSControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	s := `
-Create a basic Tenant Cluster with all its defaults. Note that some
-information of the output below slightly differs when executing conformance
-tests on different control planes.
-
----
-` + strings.TrimSpace(string(networkPoolCR)) + `
----
-` + strings.TrimSpace(string(clusterCR)) + `
----
-` + strings.TrimSpace(string(awsClusterCR)) + `
----
-` + strings.TrimSpace(string(g8sControlPlaneCR)) + `
----
-` + strings.TrimSpace(string(awsControlPlaneCR)) + `
-	`
+	s := "Create a basic Tenant Cluster with all its defaults."
 
 	return s, nil
 }

--- a/pkg/action/cl004/ac005/explainer.go
+++ b/pkg/action/cl004/ac005/explainer.go
@@ -2,74 +2,10 @@ package ac005
 
 import (
 	"context"
-	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger/microloggertest"
-
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	var err error
-
-	var cpClients k8sclient.Interface
-	{
-		c := client.ControlPlaneConfig{
-			Logger: microloggertest.New(),
-
-			KubeConfig: env.ControlPlaneKubeConfig(),
-		}
-
-		cpClients, err = client.NewControlPlane(c)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-	}
-
-	var releases []v1alpha1.Release
-	{
-		var list v1alpha1.ReleaseList
-		err := cpClients.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		releases = list.Items
-	}
-
-	crs, err := newCRs(ctx, releases, "al9qy", "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	machineDeploymentCR, err := yaml.Marshal(crs.MachineDeployment)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsMachineDeploymentCR, err := yaml.Marshal(crs.AWSMachineDeployment)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	s := `
-Create a basic Node Pool with all its defaults. Note that some information of
-the output below slightly differs when executing conformance tests on
-different control planes.
-
----
-` + strings.TrimSpace(string(machineDeploymentCR)) + `
----
-` + strings.TrimSpace(string(awsMachineDeploymentCR)) + `
-	`
+	s := "Create a basic Node Pool with all its defaults."
 
 	return s, nil
 }

--- a/pkg/action/cl005/ac001/explainer.go
+++ b/pkg/action/cl005/ac001/explainer.go
@@ -2,88 +2,10 @@ package ac001
 
 import (
 	"context"
-	"strings"
-
-	"github.com/ghodss/yaml"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger/microloggertest"
-
-	"github.com/giantswarm/awscnfm/v12/pkg/client"
-	"github.com/giantswarm/awscnfm/v12/pkg/env"
 )
 
 func (e *Explainer) explain(ctx context.Context) (string, error) {
-	var err error
-
-	var cpClients k8sclient.Interface
-	{
-		c := client.ControlPlaneConfig{
-			Logger: microloggertest.New(),
-
-			KubeConfig: env.ControlPlaneKubeConfig(),
-		}
-
-		cpClients, err = client.NewControlPlane(c)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-	}
-
-	var releases []v1alpha1.Release
-	{
-		var list v1alpha1.ReleaseList
-		err := cpClients.CtrlClient().List(
-			ctx,
-			&list,
-		)
-		if err != nil {
-			return "", microerror.Mask(err)
-		}
-
-		releases = list.Items
-	}
-
-	crs, err := newCRs(releases, "https://g8s.codename.eu-central-1.aws.gigantic.io:443")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	clusterCR, err := yaml.Marshal(crs.Cluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsClusterCR, err := yaml.Marshal(crs.AWSCluster)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	g8sControlPlaneCR, err := yaml.Marshal(crs.G8sControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	awsControlPlaneCR, err := yaml.Marshal(crs.AWSControlPlane)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	s := `
-Create a basic Tenant Cluster with all its defaults. Note that some
-information of the output below slightly differs when executing conformance
-tests on different control planes.
-
----
-` + strings.TrimSpace(string(clusterCR)) + `
----
-` + strings.TrimSpace(string(awsClusterCR)) + `
----
-` + strings.TrimSpace(string(g8sControlPlaneCR)) + `
----
-` + strings.TrimSpace(string(awsControlPlaneCR)) + `
-	`
+	s := "Create a basic Tenant Cluster with all its defaults."
 
 	return s, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

This PR removes all network dependencies from the explainers. The problem with having explainers depend on external resources is increased latency and in turn a worse user experience. With this PR execution times of even only printing the help usage dropped from **0.738** to **0.038** seconds. 



#### Before 

<pre>
$ time awscnfm cl001 ac001 -h
Create a basic Tenant Cluster with all its defaults.

Usage:
  awscnfm cl001 ac001 [flags]

Flags:
  -h, --help   help for ac001
awscnfm cl001 ac001 -h  0.13s user 0.07s system 27% cpu <b>0.738</b> total
</pre>



#### After 

<pre>
$ time awscnfm cl001 ac001 -h
Create a basic Tenant Cluster with all its defaults.

Usage:
  awscnfm cl001 ac001 [flags]

Flags:
  -h, --help   help for ac001
awscnfm cl001 ac001 -h  0.02s user 0.02s system 97% cpu <b>0.038</b> total
</pre>



#### Implication

We do not print all the CRs anymore in the explainers. The question is if this was ever useful. If we want this kind of feature in the future we could extend the commands to not apply the CRs upon execution but rather only print them to stdout in case some flag is given. For the future **we should not do more than computing dumb strings within explainers**.