### PR TITLE
fix command lookup during plan execution

### DIFF
--- a/pkg/action/cl001/ac000/executor.go
+++ b/pkg/action/cl001/ac000/executor.go
@@ -14,7 +14,7 @@ func (e *Executor) execute(ctx context.Context) error {
 	var planExecutor *plan.Executor
 	{
 		c := plan.ExecutorConfig{
-			Commands: e.command.Parent().Parent().Commands(),
+			Commands: e.command.Parent().Commands(),
 			Logger:   e.logger,
 			Plan:     Plan,
 		}

--- a/pkg/action/cl002/ac000/executor.go
+++ b/pkg/action/cl002/ac000/executor.go
@@ -14,7 +14,7 @@ func (e *Executor) execute(ctx context.Context) error {
 	var planExecutor *plan.Executor
 	{
 		c := plan.ExecutorConfig{
-			Commands: e.command.Parent().Parent().Commands(),
+			Commands: e.command.Parent().Commands(),
 			Logger:   e.logger,
 			Plan:     Plan,
 		}

--- a/pkg/action/cl003/ac000/executor.go
+++ b/pkg/action/cl003/ac000/executor.go
@@ -14,7 +14,7 @@ func (e *Executor) execute(ctx context.Context) error {
 	var planExecutor *plan.Executor
 	{
 		c := plan.ExecutorConfig{
-			Commands: e.command.Parent().Parent().Commands(),
+			Commands: e.command.Parent().Commands(),
 			Logger:   e.logger,
 			Plan:     Plan,
 		}

--- a/pkg/action/cl004/ac000/executor.go
+++ b/pkg/action/cl004/ac000/executor.go
@@ -14,7 +14,7 @@ func (e *Executor) execute(ctx context.Context) error {
 	var planExecutor *plan.Executor
 	{
 		c := plan.ExecutorConfig{
-			Commands: e.command.Parent().Parent().Commands(),
+			Commands: e.command.Parent().Commands(),
 			Logger:   e.logger,
 			Plan:     Plan,
 		}

--- a/pkg/action/cl005/ac000/executor.go
+++ b/pkg/action/cl005/ac000/executor.go
@@ -14,7 +14,7 @@ func (e *Executor) execute(ctx context.Context) error {
 	var planExecutor *plan.Executor
 	{
 		c := plan.ExecutorConfig{
-			Commands: e.command.Parent().Parent().Commands(),
+			Commands: e.command.Parent().Commands(),
 			Logger:   e.logger,
 			Plan:     Plan,
 		}

--- a/pkg/plan/executor.go
+++ b/pkg/plan/executor.go
@@ -72,32 +72,11 @@ func (e *Executor) Execute(ctx context.Context) error {
 func commandForAction(action string, commands []*cobra.Command) (*cobra.Command, error) {
 	// We get all commands of the registered actions and only want to return the
 	// command of the action we want to execute.
-	var act *cobra.Command
 	for _, c := range commands {
 		if c.Name() == action {
-			act = c
-			break
+			return c, nil
 		}
 	}
 
-	if act == nil {
-		return nil, microerror.Maskf(commandNotFoundError, action)
-	}
-
-	// Once we found the action command we need to find its own execute command,
-	// because the execute command wraps the business logic we want to execute
-	// for the test plan.
-	var exe *cobra.Command
-	for _, c := range act.Commands() {
-		if c.Name() == "execute" {
-			exe = c
-			break
-		}
-	}
-
-	if exe == nil {
-		return nil, microerror.Maskf(commandNotFoundError, "%s execute", action)
-	}
-
-	return exe, nil
+	return nil, microerror.Maskf(commandNotFoundError, action)
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

With the recent changes on the command structure the plan execution broke. This fixes the command lookup during plan execution. The problem was that commands could not be found because their location within the hierarchy changed. 