### PR TITLE
implement new plan execution

### DIFF
--- a/cmd/plan/pl001/plan.go
+++ b/cmd/plan/pl001/plan.go
@@ -1,0 +1,20 @@
+package pl001
+
+import (
+	"time"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/plan"
+)
+
+// Plan describes in which order and with which tolerance to execute actions of
+// this test plan.
+var Plan = []plan.Step{
+	{
+		Action:  "create/cluster/onenodepool",
+		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+	},
+	{
+		Action:  "verify/cluster/created",
+		Backoff: plan.NewBackoff(30*time.Minute, 3*time.Minute),
+	},
+}

--- a/cmd/plan/pl001/runner.go
+++ b/cmd/plan/pl001/runner.go
@@ -6,6 +6,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
 type runner struct {
@@ -32,5 +34,26 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var planExecutor *plan.Executor
+	{
+		c := plan.ExecutorConfig{
+			Commands: cmd.Root().Commands(),
+			Logger:   r.logger,
+			Plan:     Plan,
+		}
+
+		planExecutor, err = plan.NewExecutor(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = planExecutor.Execute(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }

--- a/pkg/plan/executor.go
+++ b/pkg/plan/executor.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -43,8 +44,22 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 }
 
 func (e *Executor) Execute(ctx context.Context) error {
+	var cmds []*cobra.Command
+	{
+		for _, c := range e.commands {
+			if c.Name() == "action" {
+				cmds = c.Commands()
+				break
+			}
+		}
+
+		if cmds == nil {
+			return microerror.Maskf(commandNotFoundError, "action")
+		}
+	}
+
 	for _, p := range e.plan {
-		c, err := commandForAction(p.Action, e.commands)
+		c, err := commandForAction(p.Action, cmds)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -70,13 +85,24 @@ func (e *Executor) Execute(ctx context.Context) error {
 }
 
 func commandForAction(action string, commands []*cobra.Command) (*cobra.Command, error) {
-	// We get all commands of the registered actions and only want to return the
-	// command of the action we want to execute.
-	for _, c := range commands {
-		if c.Name() == action {
-			return c, nil
+	var cmd *cobra.Command
+
+	cmds := append([]*cobra.Command{}, commands...)
+	acts := strings.Split(action, "/")
+
+	for _, a := range acts {
+		for _, c := range cmds {
+			if c.Name() == a {
+				cmd = c
+				cmds = c.Commands()
+				break
+			}
 		}
 	}
 
-	return nil, microerror.Maskf(commandNotFoundError, action)
+	if cmd == nil {
+		return nil, microerror.Maskf(commandNotFoundError, action)
+	}
+
+	return cmd, nil
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. With this the new plan execution is set up. 

```
$ awscnfm plan pl001 -h
Test plan pl001 launches a basic Tenant Cluster and verifies basic criteria like
the correct number of nodes and pods are running. Plan execution might take up
to 30m10s.

ACTION                      RETRY  WAIT
create/cluster/onenodepool  2s     10s
verify/cluster/created      3m0s   30m0s

Usage:
  awscnfm plan pl001 [flags]

Flags:
  -h, --help   help for pl001
```