### PR TITLE
rename action for more clarity

### DIFF
--- a/cmd/action/create/cluster/command.go
+++ b/cmd/action/create/cluster/command.go
@@ -5,7 +5,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/cmd/action/create/cluster/onenodepool"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/create/cluster/defaultcontrolplane"
 )
 
 const (
@@ -24,13 +24,13 @@ func New(config Config) (*cobra.Command, error) {
 
 	var err error
 
-	var onenodepoolCmd *cobra.Command
+	var defaultcontrolplaneCmd *cobra.Command
 	{
-		c := onenodepool.Config{
+		c := defaultcontrolplane.Config{
 			Logger: config.Logger,
 		}
 
-		onenodepoolCmd, err = onenodepool.New(c)
+		defaultcontrolplaneCmd, err = defaultcontrolplane.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -52,7 +52,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
-	c.AddCommand(onenodepoolCmd)
+	c.AddCommand(defaultcontrolplaneCmd)
 
 	return c, nil
 }

--- a/cmd/action/create/cluster/defaultcontrolplane/command.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/command.go
@@ -1,4 +1,4 @@
-package onenodepool
+package defaultcontrolplane
 
 import (
 	"github.com/giantswarm/microerror"
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	name        = "onenodepool"
-	description = "Create a basic Tenant Cluster with one basic Node Pool."
+	name        = "defaultcontrolplane"
+	description = "Create a default Tenant Cluster Control Plane without Node Pool."
 )
 
 type Config struct {

--- a/cmd/action/create/cluster/defaultcontrolplane/crs.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/crs.go
@@ -1,4 +1,4 @@
-package onenodepool
+package defaultcontrolplane
 
 import (
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/infrastructure/v1alpha2"

--- a/cmd/action/create/cluster/defaultcontrolplane/error.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/error.go
@@ -1,4 +1,4 @@
-package onenodepool
+package defaultcontrolplane
 
 import "github.com/giantswarm/microerror"
 

--- a/cmd/action/create/cluster/defaultcontrolplane/flag.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/flag.go
@@ -1,4 +1,4 @@
-package onenodepool
+package defaultcontrolplane
 
 import "github.com/spf13/cobra"
 

--- a/cmd/action/create/cluster/defaultcontrolplane/runner.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/runner.go
@@ -1,4 +1,4 @@
-package onenodepool
+package defaultcontrolplane
 
 import (
 	"context"

--- a/cmd/plan/pl001/plan.go
+++ b/cmd/plan/pl001/plan.go
@@ -10,7 +10,7 @@ import (
 // this test plan.
 var Plan = []plan.Step{
 	{
-		Action:  "create/cluster/onenodepool",
+		Action:  "create/cluster/defaultcontrolplane",
 		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
 	},
 	{


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. Renaming here for more clarity. The action itself should only create the Control Plane. Though in the test plan we should always use two actions together in order to get a cluster with Node Pools. As discussed we cannot just use a cluster without Node Pools because of some implementation details. 