### PR TITLE
add structure for action verify worker ready

### DIFF
--- a/cmd/action/verify/command.go
+++ b/cmd/action/verify/command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/cluster"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/master"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/worker"
 )
 
 const (
@@ -49,6 +50,18 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var workerCmd *cobra.Command
+	{
+		c := worker.Config{
+			Logger: config.Logger,
+		}
+
+		workerCmd, err = worker.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	f := &flag{}
 
 	r := &runner{
@@ -67,6 +80,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	c.AddCommand(clusterCmd)
 	c.AddCommand(masterCmd)
+	c.AddCommand(workerCmd)
 
 	return c, nil
 }

--- a/cmd/action/verify/worker/command.go
+++ b/cmd/action/verify/worker/command.go
@@ -1,0 +1,58 @@
+package worker
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/worker/ready"
+)
+
+const (
+	name        = "worker"
+	description = "Verify certain worker node aspects within a Tenant Cluster."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var err error
+
+	var readyCmd *cobra.Command
+	{
+		c := ready.Config{
+			Logger: config.Logger,
+		}
+
+		readyCmd, err = ready.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(readyCmd)
+
+	return c, nil
+}

--- a/cmd/action/verify/worker/error.go
+++ b/cmd/action/verify/worker/error.go
@@ -1,0 +1,21 @@
+package worker
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/verify/worker/flag.go
+++ b/cmd/action/verify/worker/flag.go
@@ -1,0 +1,13 @@
+package worker
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/verify/worker/ready/command.go
+++ b/cmd/action/verify/worker/ready/command.go
@@ -1,0 +1,41 @@
+package ready
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name  = "ready"
+	short = "Verify if all worker nodes are ready."
+	long  = "Verify if all worker nodes are ready."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/verify/worker/ready/error.go
+++ b/cmd/action/verify/worker/ready/error.go
@@ -2,18 +2,6 @@ package ready
 
 import "github.com/giantswarm/microerror"
 
-// executionFailedError is an error type for situations where Resource execution
-// cannot continue and must always fall back to operatorkit.
-//
-// This error should never be matched against and therefore there is no matcher
-// implement. For further information see:
-//
-//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
-//
-var executionFailedError = &microerror.Error{
-	Kind: "executionFailedError",
-}
-
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/cmd/action/verify/worker/ready/error.go
+++ b/cmd/action/verify/worker/ready/error.go
@@ -1,0 +1,33 @@
+package ready
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/verify/worker/ready/flag.go
+++ b/cmd/action/verify/worker/ready/flag.go
@@ -1,0 +1,24 @@
+package ready
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type flag struct {
+	TenantCluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
+}
+
+func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster must not be empty")
+	}
+
+	return nil
+}

--- a/cmd/action/verify/worker/ready/runner.go
+++ b/cmd/action/verify/worker/ready/runner.go
@@ -1,0 +1,34 @@
+package ready
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/action/verify/worker/runner.go
+++ b/cmd/action/verify/worker/runner.go
@@ -1,0 +1,39 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This is only the command structure for `awscnfm action verify worker ready`. 