### PR TITLE
add structure for verify master hostnetworkpod

### DIFF
--- a/cmd/action/verify/master/command.go
+++ b/cmd/action/verify/master/command.go
@@ -5,6 +5,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/master/hostnetworkpod"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/master/ready"
 )
 
@@ -23,6 +24,18 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	var err error
+
+	var hostnetworkpodCmd *cobra.Command
+	{
+		c := hostnetworkpod.Config{
+			Logger: config.Logger,
+		}
+
+		hostnetworkpodCmd, err = hostnetworkpod.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var readyCmd *cobra.Command
 	{
@@ -52,6 +65,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
+	c.AddCommand(hostnetworkpodCmd)
 	c.AddCommand(readyCmd)
 
 	return c, nil

--- a/cmd/action/verify/master/hostnetworkpod/command.go
+++ b/cmd/action/verify/master/hostnetworkpod/command.go
@@ -1,0 +1,51 @@
+package hostnetworkpod
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name  = "hostnetworkpod"
+	short = "Verify the number of host network pods on master nodes."
+	long  = `Check if the number of host network pods on tenant cluster master nodes
+matches the number we expect from k8scloudconfig.
+
+	* Fetch all Tenant Cluster nodes and take the the first master node by label.
+	* Compare the current pods with host network set with the expected amount of pods on master node.
+	* See also https://github.com/giantswarm/k8scloudconfig/blob/529491d591e039da1ffde03fef070101c8d4a95c/files/conf/setup-kubelet-environment#L21.
+
+The action waits up to 15 minutes to verify all pods with host network set
+are being deployed. This ensures pods (e.g. node-exporter) have enough time
+to being scheduled.
+	`
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/verify/master/hostnetworkpod/error.go
+++ b/cmd/action/verify/master/hostnetworkpod/error.go
@@ -1,0 +1,33 @@
+package hostnetworkpod
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/verify/master/hostnetworkpod/error.go
+++ b/cmd/action/verify/master/hostnetworkpod/error.go
@@ -2,18 +2,6 @@ package hostnetworkpod
 
 import "github.com/giantswarm/microerror"
 
-// executionFailedError is an error type for situations where Resource execution
-// cannot continue and must always fall back to operatorkit.
-//
-// This error should never be matched against and therefore there is no matcher
-// implement. For further information see:
-//
-//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
-//
-var executionFailedError = &microerror.Error{
-	Kind: "executionFailedError",
-}
-
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/cmd/action/verify/master/hostnetworkpod/flag.go
+++ b/cmd/action/verify/master/hostnetworkpod/flag.go
@@ -1,0 +1,24 @@
+package hostnetworkpod
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type flag struct {
+	TenantCluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
+}
+
+func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster must not be empty")
+	}
+
+	return nil
+}

--- a/cmd/action/verify/master/hostnetworkpod/runner.go
+++ b/cmd/action/verify/master/hostnetworkpod/runner.go
@@ -1,0 +1,34 @@
+package hostnetworkpod
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This is only the command structure for `awscnfm action verify master hostnetworkpod`. 