### PR TITLE
add structure and logic for verify worker hostnetworkpod

### DIFF
--- a/cmd/action/verify/worker/command.go
+++ b/cmd/action/verify/worker/command.go
@@ -5,6 +5,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/worker/hostnetworkpod"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/worker/ready"
 )
 
@@ -23,6 +24,18 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	var err error
+
+	var hostnetworkpodCmd *cobra.Command
+	{
+		c := hostnetworkpod.Config{
+			Logger: config.Logger,
+		}
+
+		hostnetworkpodCmd, err = hostnetworkpod.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var readyCmd *cobra.Command
 	{
@@ -52,6 +65,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
+	c.AddCommand(hostnetworkpodCmd)
 	c.AddCommand(readyCmd)
 
 	return c, nil

--- a/cmd/action/verify/worker/hostnetworkpod/command.go
+++ b/cmd/action/verify/worker/hostnetworkpod/command.go
@@ -1,0 +1,47 @@
+package hostnetworkpod
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name  = "hostnetworkpod"
+	short = "Verify the number of host network pods on worker nodes."
+	long  = `Check if the number of host network pods on tenant cluster worker nodes
+matches the number we expect from k8scloudconfig.
+
+	* Fetch all Tenant Cluster nodes and take the the first worker node by label.
+	* Compare the current pods with host network set with the expected amount of pods on worker node.
+	* See also https://github.com/giantswarm/k8scloudconfig/blob/529491d591e039da1ffde03fef070101c8d4a95c/files/conf/setup-kubelet-environment#L26.
+`
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/verify/worker/hostnetworkpod/error.go
+++ b/cmd/action/verify/worker/hostnetworkpod/error.go
@@ -1,0 +1,33 @@
+package hostnetworkpod
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/verify/worker/hostnetworkpod/flag.go
+++ b/cmd/action/verify/worker/hostnetworkpod/flag.go
@@ -1,0 +1,24 @@
+package hostnetworkpod
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type flag struct {
+	TenantCluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
+}
+
+func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster must not be empty")
+	}
+
+	return nil
+}

--- a/cmd/action/verify/worker/hostnetworkpod/runner.go
+++ b/cmd/action/verify/worker/hostnetworkpod/runner.go
@@ -1,0 +1,123 @@
+package hostnetworkpod
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/label"
+)
+
+// expectedPods are all host network pods which we expect to run on a worker node
+var expectedPods = []string{"aws-node", "calico-node", "cert-exporter", "kiam-agent", "kube-proxy", "node-exporter"}
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var cpClients k8sclient.Interface
+	{
+		c := client.ControlPlaneConfig{
+			Logger: e.logger,
+
+			KubeConfig: env.ControlPlaneKubeConfig(),
+		}
+
+		cpClients, err = client.NewControlPlane(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var tcClients k8sclient.Interface
+	{
+		c := client.TenantClusterConfig{
+			ControlPlane: cpClients,
+			Logger:       e.logger,
+		}
+
+		tcClients, err = client.NewTenantCluster(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+	var nodeList *corev1.NodeList
+	{
+		nodeList, err = tcClients.K8sClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var workerNode corev1.Node
+	{
+		for _, node := range nodeList.Items {
+			_, ok := node.Labels[label.WorkerNodeRole]
+			if ok {
+				workerNode = node
+				break
+			}
+
+		}
+	}
+
+	var workerPodList *corev1.PodList
+	{
+		workerPodList, err = tcClients.K8sClient().CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			FieldSelector: "spec.nodeName=" + workerNode.Name,
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var workerPods []string
+	for _, pod := range workerPodList.Items {
+		if pod.Spec.HostNetwork {
+			workerPods = append(workerPods, pod.Name)
+		}
+	}
+
+	if len(workerPods) != len(expectedPods) {
+		executionFailedError.Desc = fmt.Sprintf(
+			"The Tenant Cluster defines %d pods (%s) but it has currently %d pods (%s) with host network running",
+			len(expectedPods),
+			strings.Join(expectedPods, ", "),
+			len(workerPods),
+			strings.Join(workerPods, ", "),
+		)
+
+		return microerror.Mask(executionFailedError)
+	}
+
+	return nil
+}

--- a/cmd/action/verify/worker/hostnetworkpod/runner.go
+++ b/cmd/action/verify/worker/hostnetworkpod/runner.go
@@ -47,7 +47,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var cpClients k8sclient.Interface
 	{
 		c := client.ControlPlaneConfig{
-			Logger: e.logger,
+			Logger: r.logger,
 
 			KubeConfig: env.ControlPlaneKubeConfig(),
 		}
@@ -62,7 +62,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	{
 		c := client.TenantClusterConfig{
 			ControlPlane: cpClients,
-			Logger:       e.logger,
+			Logger:       r.logger,
+
+			TenantCluster: r.flag.TenantCluster,
 		}
 
 		tcClients, err = client.NewTenantCluster(c)
@@ -70,6 +72,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 	}
+
 	var nodeList *corev1.NodeList
 	{
 		nodeList, err = tcClients.K8sClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This is the command structure and logic for `awscnfm action verify worker hostnetworkpod`. 