### PR TITLE
add structure for kiam actions

### DIFF
--- a/cmd/action/create/command.go
+++ b/cmd/action/create/command.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/awscnfm/v12/cmd/action/create/cluster"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/create/kiam"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/create/nodepool"
 )
 
@@ -32,6 +33,18 @@ func New(config Config) (*cobra.Command, error) {
 		}
 
 		clusterCmd, err = cluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var kiamCmd *cobra.Command
+	{
+		c := kiam.Config{
+			Logger: config.Logger,
+		}
+
+		kiamCmd, err = kiam.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -66,6 +79,7 @@ func New(config Config) (*cobra.Command, error) {
 	f.Init(c)
 
 	c.AddCommand(clusterCmd)
+	c.AddCommand(kiamCmd)
 	c.AddCommand(nodepoolCmd)
 
 	return c, nil

--- a/cmd/action/create/kiam/awsapicall/command.go
+++ b/cmd/action/create/kiam/awsapicall/command.go
@@ -1,0 +1,41 @@
+package awsapicall
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name  = "awsapicall"
+	short = "TODO"
+	long  = "TODO"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/create/kiam/awsapicall/error.go
+++ b/cmd/action/create/kiam/awsapicall/error.go
@@ -1,0 +1,21 @@
+package awsapicall
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/create/kiam/awsapicall/flag.go
+++ b/cmd/action/create/kiam/awsapicall/flag.go
@@ -1,0 +1,24 @@
+package awsapicall
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type flag struct {
+	TenantCluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
+}
+
+func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster must not be empty")
+	}
+
+	return nil
+}

--- a/cmd/action/create/kiam/awsapicall/runner.go
+++ b/cmd/action/create/kiam/awsapicall/runner.go
@@ -1,0 +1,34 @@
+package awsapicall
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/action/create/kiam/command.go
+++ b/cmd/action/create/kiam/command.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/kiam/awsapicall"
-	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/kiam/podandsecret"
 )
 
 const (
@@ -37,18 +36,6 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
-	var podandsecretCmd *cobra.Command
-	{
-		c := podandsecret.Config{
-			Logger: config.Logger,
-		}
-
-		podandsecretCmd, err = podandsecret.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	f := &flag{}
 
 	r := &runner{
@@ -66,7 +53,6 @@ func New(config Config) (*cobra.Command, error) {
 	f.Init(c)
 
 	c.AddCommand(awsapicallCmd)
-	c.AddCommand(podandsecretCmd)
 
 	return c, nil
 }

--- a/cmd/action/create/kiam/command.go
+++ b/cmd/action/create/kiam/command.go
@@ -5,12 +5,12 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/kiam/awsapicall"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/create/kiam/awsapicall"
 )
 
 const (
 	name        = "kiam"
-	description = "Verify certain kiam app aspects within a Tenant Cluster."
+	description = "Create certain kiam test resources."
 )
 
 type Config struct {

--- a/cmd/action/create/kiam/error.go
+++ b/cmd/action/create/kiam/error.go
@@ -1,0 +1,21 @@
+package kiam
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/create/kiam/flag.go
+++ b/cmd/action/create/kiam/flag.go
@@ -1,0 +1,13 @@
+package kiam
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/create/kiam/runner.go
+++ b/cmd/action/create/kiam/runner.go
@@ -1,0 +1,39 @@
+package kiam
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/action/delete/command.go
+++ b/cmd/action/delete/command.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/awscnfm/v12/cmd/action/delete/cluster"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/delete/kiam"
 )
 
 const (
@@ -36,6 +37,18 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var kiamCmd *cobra.Command
+	{
+		c := kiam.Config{
+			Logger: config.Logger,
+		}
+
+		kiamCmd, err = kiam.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	f := &flag{}
 
 	r := &runner{
@@ -53,6 +66,7 @@ func New(config Config) (*cobra.Command, error) {
 	f.Init(c)
 
 	c.AddCommand(clusterCmd)
+	c.AddCommand(kiamCmd)
 
 	return c, nil
 }

--- a/cmd/action/delete/kiam/awsapicall/command.go
+++ b/cmd/action/delete/kiam/awsapicall/command.go
@@ -1,0 +1,41 @@
+package awsapicall
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name  = "awsapicall"
+	short = "TODO"
+	long  = "TODO"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/delete/kiam/awsapicall/error.go
+++ b/cmd/action/delete/kiam/awsapicall/error.go
@@ -1,0 +1,21 @@
+package awsapicall
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/delete/kiam/awsapicall/flag.go
+++ b/cmd/action/delete/kiam/awsapicall/flag.go
@@ -1,0 +1,24 @@
+package awsapicall
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type flag struct {
+	TenantCluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
+}
+
+func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster must not be empty")
+	}
+
+	return nil
+}

--- a/cmd/action/delete/kiam/awsapicall/runner.go
+++ b/cmd/action/delete/kiam/awsapicall/runner.go
@@ -1,0 +1,34 @@
+package awsapicall
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/action/delete/kiam/command.go
+++ b/cmd/action/delete/kiam/command.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/kiam/awsapicall"
-	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/kiam/podandsecret"
 )
 
 const (
@@ -37,18 +36,6 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
-	var podandsecretCmd *cobra.Command
-	{
-		c := podandsecret.Config{
-			Logger: config.Logger,
-		}
-
-		podandsecretCmd, err = podandsecret.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	f := &flag{}
 
 	r := &runner{
@@ -66,7 +53,6 @@ func New(config Config) (*cobra.Command, error) {
 	f.Init(c)
 
 	c.AddCommand(awsapicallCmd)
-	c.AddCommand(podandsecretCmd)
 
 	return c, nil
 }

--- a/cmd/action/delete/kiam/command.go
+++ b/cmd/action/delete/kiam/command.go
@@ -5,12 +5,12 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/cmd/action/verify/kiam/awsapicall"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/delete/kiam/awsapicall"
 )
 
 const (
 	name        = "kiam"
-	description = "Verify certain kiam app aspects within a Tenant Cluster."
+	description = "Delete certain kiam test resources."
 )
 
 type Config struct {

--- a/cmd/action/delete/kiam/error.go
+++ b/cmd/action/delete/kiam/error.go
@@ -1,0 +1,21 @@
+package kiam
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/delete/kiam/flag.go
+++ b/cmd/action/delete/kiam/flag.go
@@ -1,0 +1,13 @@
+package kiam
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/delete/kiam/runner.go
+++ b/cmd/action/delete/kiam/runner.go
@@ -1,0 +1,39 @@
+package kiam
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/action/verify/kiam/awsapicall/command.go
+++ b/cmd/action/verify/kiam/awsapicall/command.go
@@ -1,0 +1,41 @@
+package awsapicall
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name  = "awsapicall"
+	short = "TODO"
+	long  = "TODO"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/verify/kiam/awsapicall/error.go
+++ b/cmd/action/verify/kiam/awsapicall/error.go
@@ -1,0 +1,21 @@
+package awsapicall
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/verify/kiam/awsapicall/flag.go
+++ b/cmd/action/verify/kiam/awsapicall/flag.go
@@ -1,0 +1,24 @@
+package awsapicall
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type flag struct {
+	TenantCluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
+}
+
+func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster must not be empty")
+	}
+
+	return nil
+}

--- a/cmd/action/verify/kiam/awsapicall/runner.go
+++ b/cmd/action/verify/kiam/awsapicall/runner.go
@@ -1,0 +1,34 @@
+package awsapicall
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This is only the command structure for three new kiam actions. Together they test that calls to the AWS API can be made. 

```
awscnfm action create kiam awsapicall
awscnfm action verify kiam awsapicall
awscnfm action delete kiam awsapicall
```