### PR TITLE
add validation for plans to fail fast

### DIFF
--- a/cmd/plan/pl001/runner.go
+++ b/cmd/plan/pl001/runner.go
@@ -50,6 +50,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
+	err = planExecutor.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	err = planExecutor.Execute(ctx)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This adds some validation capabilities so that we fail fast in case something is not wired up correctly. Otherwise it might happen that a plan is being executed for two hours and only then someone finds out that there was a typo in the action path. 