### PR TITLE
add structure for update commands

### DIFF
--- a/cmd/action/command.go
+++ b/cmd/action/command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/cmd/action/create"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/delete"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/update"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/verify"
 )
 
@@ -50,6 +51,18 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var updateCmd *cobra.Command
+	{
+		c := update.Config{
+			Logger: config.Logger,
+		}
+
+		updateCmd, err = update.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var verifyCmd *cobra.Command
 	{
 		c := verify.Config{
@@ -80,6 +93,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	c.AddCommand(createCmd)
 	c.AddCommand(deleteCmd)
+	c.AddCommand(updateCmd)
 	c.AddCommand(verifyCmd)
 
 	return c, nil

--- a/cmd/action/update/cluster/command.go
+++ b/cmd/action/update/cluster/command.go
@@ -1,0 +1,86 @@
+package cluster
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/action/update/cluster/major"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/update/cluster/minor"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/update/cluster/patch"
+)
+
+const (
+	name        = "cluster"
+	description = "Update Tenant Clusters within a Control Plane."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var err error
+
+	var majorCmd *cobra.Command
+	{
+		c := major.Config{
+			Logger: config.Logger,
+		}
+
+		majorCmd, err = major.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var minorCmd *cobra.Command
+	{
+		c := minor.Config{
+			Logger: config.Logger,
+		}
+
+		minorCmd, err = minor.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var patchCmd *cobra.Command
+	{
+		c := patch.Config{
+			Logger: config.Logger,
+		}
+
+		patchCmd, err = patch.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(majorCmd)
+	c.AddCommand(minorCmd)
+	c.AddCommand(patchCmd)
+
+	return c, nil
+}

--- a/cmd/action/update/cluster/error.go
+++ b/cmd/action/update/cluster/error.go
@@ -1,0 +1,21 @@
+package cluster
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/update/cluster/flag.go
+++ b/cmd/action/update/cluster/flag.go
@@ -1,0 +1,13 @@
+package cluster
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/update/cluster/major/command.go
+++ b/cmd/action/update/cluster/major/command.go
@@ -1,0 +1,40 @@
+package major
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "major"
+	description = "Update a Tenant Cluster to the latest major release."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/update/cluster/major/error.go
+++ b/cmd/action/update/cluster/major/error.go
@@ -1,0 +1,21 @@
+package major
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/update/cluster/major/flag.go
+++ b/cmd/action/update/cluster/major/flag.go
@@ -1,0 +1,13 @@
+package major
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/update/cluster/major/runner.go
+++ b/cmd/action/update/cluster/major/runner.go
@@ -1,0 +1,34 @@
+package major
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/action/update/cluster/minor/command.go
+++ b/cmd/action/update/cluster/minor/command.go
@@ -1,0 +1,40 @@
+package minor
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "minor"
+	description = "Update a Tenant Cluster to the latest minor release."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/update/cluster/minor/error.go
+++ b/cmd/action/update/cluster/minor/error.go
@@ -1,0 +1,21 @@
+package minor
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/update/cluster/minor/flag.go
+++ b/cmd/action/update/cluster/minor/flag.go
@@ -1,0 +1,13 @@
+package minor
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/update/cluster/minor/runner.go
+++ b/cmd/action/update/cluster/minor/runner.go
@@ -1,0 +1,34 @@
+package minor
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/action/update/cluster/patch/command.go
+++ b/cmd/action/update/cluster/patch/command.go
@@ -1,0 +1,40 @@
+package patch
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "patch"
+	description = "Update a Tenant Cluster to the latest patch release."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/update/cluster/patch/error.go
+++ b/cmd/action/update/cluster/patch/error.go
@@ -1,0 +1,21 @@
+package patch
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/update/cluster/patch/flag.go
+++ b/cmd/action/update/cluster/patch/flag.go
@@ -1,0 +1,13 @@
+package patch
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/update/cluster/patch/runner.go
+++ b/cmd/action/update/cluster/patch/runner.go
@@ -1,0 +1,34 @@
+package patch
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/action/update/cluster/runner.go
+++ b/cmd/action/update/cluster/runner.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/action/update/command.go
+++ b/cmd/action/update/command.go
@@ -1,0 +1,58 @@
+package update
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/action/update/cluster"
+)
+
+const (
+	name        = "update"
+	description = "Update resources for conformance tests, e.g. Tenant Cluster CRs."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var err error
+
+	var clusterCmd *cobra.Command
+	{
+		c := cluster.Config{
+			Logger: config.Logger,
+		}
+
+		clusterCmd, err = cluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(clusterCmd)
+
+	return c, nil
+}

--- a/cmd/action/update/error.go
+++ b/cmd/action/update/error.go
@@ -1,0 +1,21 @@
+package update
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/update/flag.go
+++ b/cmd/action/update/flag.go
@@ -1,0 +1,13 @@
+package update
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/update/runner.go
+++ b/cmd/action/update/runner.go
@@ -1,0 +1,39 @@
+package update
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This is only the command structure for `awscnfm action update cluster`. 

```
$ awscnfm action update cluster
Update Tenant Clusters within a Control Plane.

Usage:
  awscnfm action update cluster [flags]
  awscnfm action update cluster [command]

Available Commands:
  major       Update a Tenant Cluster to the latest major release.
  minor       Update a Tenant Cluster to the latest minor release.
  patch       Update a Tenant Cluster to the latest patch release.

Flags:
  -h, --help   help for cluster

Use "awscnfm action update cluster [command] --help" for more information about a command.
```