### PR TITLE
let cluster ids be given for cluster creation

### DIFF
--- a/cmd/action/create/cluster/defaultcontrolplane/crs.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/crs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/giantswarm/awscnfm/v12/pkg/release"
 )
 
-func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, error) {
+func newCRs(releases []v1alpha1.Release, host string, id string) (v1alpha2.ClusterCRs, error) {
 	var err error
 
 	var p *release.Patch
@@ -31,6 +31,7 @@ func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, erro
 	var crs v1alpha2.ClusterCRs
 	{
 		c := v1alpha2.ClusterCRsConfig{
+			ClusterID:         id,
 			Credential:        key.Credential,
 			Domain:            key.DomainFromHost(host),
 			Description:       "awscnfm action create cluster onenodepool",

--- a/cmd/action/create/cluster/defaultcontrolplane/flag.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/flag.go
@@ -1,13 +1,31 @@
 package defaultcontrolplane
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/valid"
+)
 
 type flag struct {
+	// TenantCluster is optional for cluster creations. A random cluster ID will
+	// be generated when none is provided.
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster != "" {
+		err := valid.ID(f.TenantCluster)
+		if err != nil {
+			return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster %s", err.Error())
+		}
+	}
+
 	return nil
 }

--- a/cmd/action/create/cluster/defaultcontrolplane/runner.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/runner.go
@@ -66,7 +66,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		releases = list.Items
 	}
 
-	crs, err := newCRs(releases, cpClients.RESTConfig().Host)
+	crs, err := newCRs(releases, cpClients.RESTConfig().Host, r.flag.TenantCluster)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/action/create/cluster/singlecontrolplane/crs.go
+++ b/cmd/action/create/cluster/singlecontrolplane/crs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/giantswarm/awscnfm/v12/pkg/release"
 )
 
-func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, error) {
+func newCRs(releases []v1alpha1.Release, host string, id string) (v1alpha2.ClusterCRs, error) {
 	var err error
 
 	var p *release.Patch
@@ -31,6 +31,7 @@ func newCRs(releases []v1alpha1.Release, host string) (v1alpha2.ClusterCRs, erro
 	var crs v1alpha2.ClusterCRs
 	{
 		c := v1alpha2.ClusterCRsConfig{
+			ClusterID:         id,
 			Credential:        key.Credential,
 			Domain:            key.DomainFromHost(host),
 			Description:       "awscnfm action create cluster single-master onenodepool",

--- a/cmd/action/create/cluster/singlecontrolplane/flag.go
+++ b/cmd/action/create/cluster/singlecontrolplane/flag.go
@@ -1,13 +1,31 @@
 package singlecontrolplane
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/valid"
+)
 
 type flag struct {
+	// TenantCluster is optional for cluster creations. A random cluster ID will
+	// be generated when none is provided.
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster != "" {
+		err := valid.ID(f.TenantCluster)
+		if err != nil {
+			return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster %s", err.Error())
+		}
+	}
+
 	return nil
 }

--- a/cmd/action/create/cluster/singlecontrolplane/runner.go
+++ b/cmd/action/create/cluster/singlecontrolplane/runner.go
@@ -66,7 +66,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		releases = list.Items
 	}
 
-	crs, err := newCRs(releases, cpClients.RESTConfig().Host)
+	crs, err := newCRs(releases, cpClients.RESTConfig().Host, r.flag.TenantCluster)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/valid/error.go
+++ b/pkg/valid/error.go
@@ -1,0 +1,12 @@
+package valid
+
+import "github.com/giantswarm/microerror"
+
+var invalidIDError = &microerror.Error{
+	Kind: "invalidIDError",
+}
+
+// IsInvalidID asserts invalidIDError.
+func IsInvalidID(err error) bool {
+	return microerror.Cause(err) == invalidIDError
+}

--- a/pkg/valid/id.go
+++ b/pkg/valid/id.go
@@ -1,0 +1,33 @@
+package valid
+
+import (
+	"regexp"
+
+	"github.com/giantswarm/microerror"
+)
+
+var (
+	startsWithLetter   = regexp.MustCompile(`^[a-z]`)
+	containsNumber     = regexp.MustCompile(`[0-9]`)
+	containsWhitespace = regexp.MustCompile(`[\s]`)
+)
+
+func ID(id string) error {
+	if !startsWithLetter.MatchString(id) {
+		return microerror.Maskf(invalidIDError, "must start with letter")
+	}
+
+	if !containsNumber.MatchString(id) {
+		return microerror.Maskf(invalidIDError, "must contain number")
+	}
+
+	if containsWhitespace.MatchString(id) {
+		return microerror.Maskf(invalidIDError, "must not contain whitespace")
+	}
+
+	if len(id) != 5 {
+		return microerror.Maskf(invalidIDError, "must be have length of 5")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This allows to provide a cluster ID for cluster creation. The new plan execution will consider this and make it easier to execute plans. 



```
$ awscnfm action create cluster defaultcontrolplane -c ""
```



```
$ awscnfm action create cluster defaultcontrolplane -c " "
panic: {"kind":"invalidFlagsError","annotation":"-c/--tenant-cluster invalid id error: must start with letter","stack":[{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/flag.go","line":28},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/runner.go","line":27},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go","line":78}]}

goroutine 1 [running]:
main.main()
	/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go:28 +0x2af
```



```
$ awscnfm action create cluster defaultcontrolplane -c "a "
panic: {"kind":"invalidFlagsError","annotation":"-c/--tenant-cluster invalid id error: must contain number","stack":[{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/flag.go","line":28},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/runner.go","line":27},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go","line":78}]}

goroutine 1 [running]:
main.main()
	/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go:28 +0x2af
```



```
$ awscnfm action create cluster defaultcontrolplane -c "a 5"
panic: {"kind":"invalidFlagsError","annotation":"-c/--tenant-cluster invalid id error: must not contain whitespace","stack":[{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/flag.go","line":28},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/runner.go","line":27},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go","line":78}]}

goroutine 1 [running]:
main.main()
	/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go:28 +0x2af
```



```
$ awscnfm action create cluster defaultcontrolplane -c "a5"
panic: {"kind":"invalidFlagsError","annotation":"-c/--tenant-cluster invalid id error: must be have length of 5","stack":[{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/flag.go","line":28},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/runner.go","line":27},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go","line":78}]}

goroutine 1 [running]:
main.main()
	/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go:28 +0x2af
```



```
$ awscnfm action create cluster defaultcontrolplane -c "a5hh33"
panic: {"kind":"invalidFlagsError","annotation":"-c/--tenant-cluster invalid id error: must be have length of 5","stack":[{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/flag.go","line":28},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/cmd/action/create/cluster/defaultcontrolplane/runner.go","line":27},{"file":"/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go","line":78}]}

goroutine 1 [running]:
main.main()
	/Users/xh3b4sd/go/src/github.com/giantswarm/awscnfm/main.go:28 +0x2af
```



```
$ awscnfm action create cluster defaultcontrolplane -c "a5hh3"
```