### PR TITLE
fix plan pl005 by injecting new cluster ID

### DIFF
--- a/cmd/plan/pl005/runner.go
+++ b/cmd/plan/pl005/runner.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
@@ -41,7 +42,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		c := plan.ExecutorConfig{
 			Commands: cmd.Root().Commands(),
 			Logger:   r.logger,
-			Plan:     Plan,
+
+			Plan:          Plan,
+			TenantCluster: generate.ID(),
 		}
 
 		planExecutor, err = plan.NewExecutor(c)


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Based on https://github.com/giantswarm/awscnfm/pull/208. This fixes the missing cluster ID generation in plan `pl005`. 