### PR TITLE
Action create netpol defaultnetpol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add action to create network policy test resources.
+
 ## [12.6.0] - 2020-11-10
 
 

--- a/cmd/action/create/command.go
+++ b/cmd/action/create/command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/awscnfm/v12/cmd/action/create/cluster"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/create/kiam"
+	"github.com/giantswarm/awscnfm/v12/cmd/action/create/netpol"
 	"github.com/giantswarm/awscnfm/v12/cmd/action/create/nodepool"
 )
 
@@ -50,6 +51,18 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var netpolCmd *cobra.Command
+	{
+		c := netpol.Config{
+			Logger: config.Logger,
+		}
+
+		netpolCmd, err = netpol.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodepoolCmd *cobra.Command
 	{
 		c := nodepool.Config{
@@ -80,6 +93,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	c.AddCommand(clusterCmd)
 	c.AddCommand(kiamCmd)
+	c.AddCommand(netpolCmd)
 	c.AddCommand(nodepoolCmd)
 
 	return c, nil

--- a/cmd/action/create/netpol/command.go
+++ b/cmd/action/create/netpol/command.go
@@ -1,0 +1,58 @@
+package netpol
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/cmd/action/create/netpol/defaultnetpol"
+)
+
+const (
+	name        = "netpol"
+	description = "Create network policies test resources."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var err error
+
+	var defaultnetpolCmd *cobra.Command
+	{
+		c := defaultnetpol.Config{
+			Logger: config.Logger,
+		}
+
+		defaultnetpolCmd, err = defaultnetpol.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(defaultnetpolCmd)
+
+	return c, nil
+}

--- a/cmd/action/create/netpol/defaultnetpol/command.go
+++ b/cmd/action/create/netpol/defaultnetpol/command.go
@@ -9,7 +9,12 @@ import (
 const (
 	name  = "defaultnetpol"
 	short = "Create a default network policy 'deny-from-all' and test pod which will be used to test the network policy."
-	long  = `Create a default network policy that denies traffic from any other namespaces in default namespace and a simple pod running in default namespace that can be used for testing if the network policy work.
+	long  = `Create a test resources for a default network policy that denies traffic from other namespaces.
+Created resources:
+* namespace 'test'
+* network policy 'deny-from-other-namespaces' in namespace 'test'
+* nginx pod running in 'test' namespace
+* service for the nginx to test the connection to the pod
 `
 )
 

--- a/cmd/action/create/netpol/defaultnetpol/command.go
+++ b/cmd/action/create/netpol/defaultnetpol/command.go
@@ -1,0 +1,42 @@
+package defaultnetpol
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name  = "defaultnetpol"
+	short = "Create a default network policy 'deny-from-all' and test pod which will be used to test the network policy."
+	long  = `Create a default network policy that denies traffic from any other namespaces in default namespace and a simple pod running in default namespace that can be used for testing if the network policy work.
+`
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: short,
+		Long:  long,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/action/create/netpol/defaultnetpol/error.go
+++ b/cmd/action/create/netpol/defaultnetpol/error.go
@@ -2,18 +2,6 @@ package defaultnetpol
 
 import "github.com/giantswarm/microerror"
 
-// executionFailedError is an error type for situations where Resource execution
-// cannot continue and must always fall back to operatorkit.
-//
-// This error should never be matched against and therefore there is no matcher
-// implement. For further information see:
-//
-//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
-//
-var executionFailedError = &microerror.Error{
-	Kind: "executionFailedError",
-}
-
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }

--- a/cmd/action/create/netpol/defaultnetpol/error.go
+++ b/cmd/action/create/netpol/defaultnetpol/error.go
@@ -1,0 +1,33 @@
+package defaultnetpol
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/create/netpol/defaultnetpol/flag.go
+++ b/cmd/action/create/netpol/defaultnetpol/flag.go
@@ -1,0 +1,24 @@
+package defaultnetpol
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+)
+
+type flag struct {
+	TenantCluster string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
+}
+
+func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "-c/--tenant-cluster must not be empty")
+	}
+
+	return nil
+}

--- a/cmd/action/create/netpol/defaultnetpol/namespace.go
+++ b/cmd/action/create/netpol/defaultnetpol/namespace.go
@@ -1,0 +1,18 @@
+package defaultnetpol
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
+)
+
+// netPolTestNamespace will create a new namespace which will be used for testing the network policy
+func netPolTestNamespace() *apiv1.Namespace {
+	ns := &apiv1.Namespace{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.NetPolTestNamespaceName,
+		},
+	}
+	return ns
+}

--- a/cmd/action/create/netpol/defaultnetpol/namespace.go
+++ b/cmd/action/create/netpol/defaultnetpol/namespace.go
@@ -11,7 +11,7 @@ import (
 func netPolTestNamespace() *apiv1.Namespace {
 	ns := &apiv1.Namespace{
 		ObjectMeta: apismetav1.ObjectMeta{
-			Name:      key.NetPolTestNamespaceName,
+			Name: key.NetPolTestNamespaceName,
 		},
 	}
 	return ns

--- a/cmd/action/create/netpol/defaultnetpol/netpol.go
+++ b/cmd/action/create/netpol/defaultnetpol/netpol.go
@@ -1,0 +1,38 @@
+package defaultnetpol
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
+	"github.com/giantswarm/awscnfm/v12/pkg/project"
+)
+
+// defaultNetworkPolicy will create a 'deny-from-all-namespaces' network policy
+// https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/04-deny-traffic-from-other-namespaces.md
+func defaultNetworkPolicy() *networkingv1.NetworkPolicy {
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.NetPolName,
+			Namespace: key.NetPolTestNamespaceName,
+			Labels: map[string]string{
+				key.LabelManagedBy: project.Name(),
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &apismetav1.LabelSelector{},
+						},
+					},
+				},
+			},
+			PodSelector: apismetav1.LabelSelector{
+				MatchLabels: map[string]string{},
+			},
+		},
+	}
+	return np
+}

--- a/cmd/action/create/netpol/defaultnetpol/pod.go
+++ b/cmd/action/create/netpol/defaultnetpol/pod.go
@@ -1,0 +1,61 @@
+package defaultnetpol
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
+	"github.com/giantswarm/awscnfm/v12/pkg/project"
+)
+
+// nginxTestPod will create a test pod running nginx in the test namespace
+func nginxTestPod(dockerRegistry string) *apiv1.Pod {
+	cpu := resource.MustParse("250m")
+	memory := resource.MustParse("200Mi")
+
+	pod := &apiv1.Pod{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.NetPolNginxTestPodName,
+			Namespace: key.NetPolTestNamespaceName,
+			Labels: map[string]string{
+				key.LabelApp:       key.NetPolNginxTestPodAppLabel,
+				key.LabelManagedBy: project.Name(),
+			},
+		},
+		Spec: apiv1.PodSpec{
+			Containers: []apiv1.Container{
+				{
+					Name:  name,
+					Image: podDockerImage(dockerRegistry),
+					Resources: apiv1.ResourceRequirements{
+						Limits: apiv1.ResourceList{
+							apiv1.ResourceCPU:    cpu,
+							apiv1.ResourceMemory: memory,
+						},
+						Requests: apiv1.ResourceList{
+							apiv1.ResourceCPU:    cpu,
+							apiv1.ResourceMemory: memory,
+						},
+					},
+					Ports: []apiv1.ContainerPort{
+						{
+							ContainerPort: 80,
+							Name:          "http",
+							Protocol:      apiv1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			RestartPolicy: apiv1.RestartPolicyNever,
+		},
+	}
+
+	return pod
+}
+
+func podDockerImage(dockerRegistry string) string {
+	return fmt.Sprintf("%s/giantswarm/nginx:1.18-alpine", dockerRegistry)
+}

--- a/cmd/action/create/netpol/defaultnetpol/runner.go
+++ b/cmd/action/create/netpol/defaultnetpol/runner.go
@@ -107,7 +107,6 @@ func (r *runner) createTestNamespace(ctx context.Context, ctrlClient k8sruntimec
 	return nil
 }
 
-
 // createDefaultNetpol will create a default network policy 'deny-from-all' in the test namespace
 func (r *runner) createDefaultNetpol(ctx context.Context, ctrlClient k8sruntimeclient.Client) error {
 	networkPolicy := defaultNetworkPolicy()

--- a/cmd/action/create/netpol/defaultnetpol/runner.go
+++ b/cmd/action/create/netpol/defaultnetpol/runner.go
@@ -1,0 +1,146 @@
+package defaultnetpol
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+	k8sruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/client"
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var cpClients k8sclient.Interface
+	{
+		c := client.ControlPlaneConfig{
+			Logger: r.logger,
+
+			KubeConfig: env.ControlPlaneKubeConfig(),
+		}
+
+		cpClients, err = client.NewControlPlane(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var tcClients k8sclient.Interface
+	{
+		c := client.TenantClusterConfig{
+			ControlPlane: cpClients,
+			Logger:       r.logger,
+
+			TenantCluster: r.flag.TenantCluster,
+		}
+
+		tcClients, err = client.NewTenantCluster(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	dockerRegistry, err := key.FetchDockerRegistry(ctx, cpClients.CtrlClient())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.createTestNamespace(ctx, tcClients.CtrlClient())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.createDefaultNetpol(ctx, tcClients.CtrlClient())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.createTestPod(ctx, tcClients.CtrlClient(), dockerRegistry)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.createTestSvc(ctx, tcClients.CtrlClient())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// createTestNamespace will create a test namespace
+func (r *runner) createTestNamespace(ctx context.Context, ctrlClient k8sruntimeclient.Client) error {
+	ns := netPolTestNamespace()
+
+	err := ctrlClient.Create(ctx, ns)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+
+// createDefaultNetpol will create a default network policy 'deny-from-all' in the test namespace
+func (r *runner) createDefaultNetpol(ctx context.Context, ctrlClient k8sruntimeclient.Client) error {
+	networkPolicy := defaultNetworkPolicy()
+
+	err := ctrlClient.Create(ctx, networkPolicy)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// createTestPod will create a pod running and exposing nginx in the test namespace
+// the pod will be used to test the network policy
+func (r *runner) createTestPod(ctx context.Context, ctrlClient k8sruntimeclient.Client, dockerRegistry string) error {
+	pod := nginxTestPod(dockerRegistry)
+
+	err := ctrlClient.Create(ctx, pod)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// createTestSvc will create a service pointing to the nginx test pod
+func (r *runner) createTestSvc(ctx context.Context, ctrlClient k8sruntimeclient.Client) error {
+	svc := nginxTestPodService()
+
+	err := ctrlClient.Create(ctx, svc)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/action/create/netpol/defaultnetpol/service.go
+++ b/cmd/action/create/netpol/defaultnetpol/service.go
@@ -1,0 +1,37 @@
+package defaultnetpol
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/key"
+	"github.com/giantswarm/awscnfm/v12/pkg/project"
+)
+
+// nginxTestPodService will create a service pointing to nginx test pod
+func nginxTestPodService() *apiv1.Service {
+	svc := &apiv1.Service{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.NetPolNginxSvcName,
+			Namespace: key.NetPolTestNamespaceName,
+			Labels: map[string]string{
+				key.LabelApp:       name,
+				key.LabelManagedBy: project.Name(),
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: apiv1.ProtocolTCP,
+					Port:     80,
+				},
+			},
+			Selector: map[string]string{
+				key.LabelApp: key.NetPolNginxTestPodAppLabel,
+			},
+		},
+	}
+	return svc
+}

--- a/cmd/action/create/netpol/error.go
+++ b/cmd/action/create/netpol/error.go
@@ -1,0 +1,21 @@
+package netpol
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/action/create/netpol/flag.go
+++ b/cmd/action/create/netpol/flag.go
@@ -1,0 +1,13 @@
+package netpol
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/action/create/netpol/runner.go
+++ b/cmd/action/create/netpol/runner.go
@@ -1,0 +1,39 @@
+package netpol
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/key/error.go
+++ b/pkg/key/error.go
@@ -1,0 +1,15 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+// executionFailedError is an error type for situations where Resource execution
+// cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -1,8 +1,14 @@
 package key
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	"github.com/giantswarm/microerror"
+	valuemodifierpath "github.com/giantswarm/valuemodifier/path"
+	apiv1 "k8s.io/api/core/v1"
+	k8sruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/awscnfm/v12/pkg/project"
 )
@@ -18,6 +24,26 @@ const (
 
 const (
 	KiamTestNamespace = "kube-system"
+)
+
+const (
+	draughtsmanNamespace                  = "draughtsman"
+	draughtsmanConfigMapName              = "draughtsman-values-configmap"
+	draughtsmanConfigMapDataKey           = "values"
+	draughtsmanConfigMapDockerRegistryKey = "Installation.V1.Registry.Domain"
+)
+
+const (
+	NetPolDefaultNamespaceName = "default"
+	NetPolTestNamespaceName    = "test"
+
+	NetPolName                 = "deny-from-all-namespaces"
+	NetPolNginxTestPodName     = "netpol-nginx-test-pod"
+	NetPolNginxTestPodAppLabel = "nginx-test-pod"
+	NetPolNginxSvcName         = "netpol-nginx-test-svc"
+
+	LabelApp       = "app"
+	LabelManagedBy = "managed-by"
 )
 
 func APIEndpoint(id string, base string) string {
@@ -39,6 +65,14 @@ func KiamTestNetPolName() string {
 	return fmt.Sprintf("%s-kiam-test", project.Name())
 }
 
+func NetPolCurlTestCommand() string {
+	return fmt.Sprintf("/usr/bin/curl --connect-timeout 5 %s.%s.svc", NetPolNginxSvcName, NetPolTestNamespaceName)
+}
+
+func NetPolTestJobName(namespace string) string {
+	return fmt.Sprintf("%s-netpol-%s-job", project.Name(), namespace)
+}
+
 func RegionFromHost(h string) string {
 	h = strings.Split(DomainFromHost(h), ".")[1]
 	// Domain in giraffe is giraffe.pek.aws.k8s.adidas.com.cn which does not follow the convention
@@ -46,4 +80,45 @@ func RegionFromHost(h string) string {
 		h = "cn-north-1"
 	}
 	return h
+}
+
+func FetchDockerRegistry(ctx context.Context, cpCtrlClient k8sruntimeclient.Client) (string, error) {
+	var dockerRegistry string
+
+	cm := &apiv1.ConfigMap{}
+
+	err := cpCtrlClient.Get(
+		ctx,
+		k8sruntimeclient.ObjectKey{
+			Name:      draughtsmanConfigMapName,
+			Namespace: draughtsmanNamespace,
+		},
+		cm)
+
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	var valueReaderService *valuemodifierpath.Service
+	{
+		valueReaderConfig := valuemodifierpath.DefaultConfig()
+		valueReaderConfig.InputBytes = []byte(cm.Data[draughtsmanConfigMapDataKey])
+		valueReaderService, err = valuemodifierpath.New(valueReaderConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		value, err := valueReaderService.Get(draughtsmanConfigMapDockerRegistryKey)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		var ok bool
+		dockerRegistry, ok = value.(string)
+		if !ok {
+			return "", microerror.Maskf(executionFailedError, "Failed to parse DockerRegistry value from draughtsman configmap on CP.")
+		}
+	}
+
+	return dockerRegistry, nil
 }


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/13955

Create a test resources for a default network policy that denies traffic from other namespaces.
Created resources:
* namespace 'test'
* network policy 'deny-from-other-namespaces' in namespace 'test'
* nginx pod running in 'test' namespace
* service for the nginx to test the connection to the pod

the other actions will follow soon after

## Checklist

- [x] Update changelog in CHANGELOG.md.
