### PR TITLE
do not print newline in logs

### DIFF
--- a/cmd/action/create/cluster/defaultcontrolplane/runner.go
+++ b/cmd/action/create/cluster/defaultcontrolplane/runner.go
@@ -72,7 +72,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	{
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("creating crs for tenant cluster %s\n", crs.Cluster.GetName()))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("creating crs for tenant cluster %s", crs.Cluster.GetName()))
 
 		err = cpClients.CtrlClient().Create(ctx, crs.Cluster)
 		if err != nil {

--- a/cmd/action/create/cluster/singlecontrolplane/runner.go
+++ b/cmd/action/create/cluster/singlecontrolplane/runner.go
@@ -72,7 +72,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	{
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("creating crs for tenant cluster %s\n", crs.Cluster.GetName()))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("creating crs for tenant cluster %s", crs.Cluster.GetName()))
 
 		err = cpClients.CtrlClient().Create(ctx, crs.Cluster)
 		if err != nil {


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

Executing the conformance tests I noticed something was a little funky with the logs. The cluster ID had a newline at the end like `7qgep\n`. 

```
$ awscnfm plan pl001
{"caller":"github.com/giantswarm/micrologger@v0.3.4/activation_logger.go:104","level":"info","message":"executing action `create/cluster/defaultcontrolplane`","time":"2020-11-17T15:11:02.600622+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.4/activation_logger.go:104","level":"info","message":"creating crs for tenant cluster 7qgep\n","time":"2020-11-17T15:11:03.02416+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.3.4/activation_logger.go:104","level":"info","message":"executing action `verify/cluster/created`","time":"2020-11-17T15:11:03.781059+00:00"}
...
```