### PR TITLE
make plan help usage more readable

### DIFF
--- a/cmd/plan/pl001/command.go
+++ b/cmd/plan/pl001/command.go
@@ -56,7 +56,7 @@ func mustLong() string {
 	t := [][]string{{"ACTION", "RETRY", "WAIT"}}
 
 	for _, s := range Plan {
-		t = append(t, []string{s.Action, s.Backoff.Interval().String(), s.Backoff.Wait().String()})
+		t = append(t, []string{s.Action.String(), s.Backoff.Interval().String(), s.Backoff.Wait().String()})
 	}
 
 	colourized := table.Colourize(t)

--- a/cmd/plan/pl002/command.go
+++ b/cmd/plan/pl002/command.go
@@ -56,7 +56,7 @@ func mustLong() string {
 	t := [][]string{{"ACTION", "RETRY", "WAIT"}}
 
 	for _, s := range Plan {
-		t = append(t, []string{s.Action, s.Backoff.Interval().String(), s.Backoff.Wait().String()})
+		t = append(t, []string{s.Action.String(), s.Backoff.Interval().String(), s.Backoff.Wait().String()})
 	}
 
 	colourized := table.Colourize(t)

--- a/cmd/plan/pl003/command.go
+++ b/cmd/plan/pl003/command.go
@@ -56,7 +56,7 @@ func mustLong() string {
 	t := [][]string{{"ACTION", "RETRY", "WAIT"}}
 
 	for _, s := range Plan {
-		t = append(t, []string{s.Action, s.Backoff.Interval().String(), s.Backoff.Wait().String()})
+		t = append(t, []string{s.Action.String(), s.Backoff.Interval().String(), s.Backoff.Wait().String()})
 	}
 
 	colourized := table.Colourize(t)

--- a/cmd/plan/pl004/command.go
+++ b/cmd/plan/pl004/command.go
@@ -56,7 +56,7 @@ func mustLong() string {
 	t := [][]string{{"ACTION", "RETRY", "WAIT"}}
 
 	for _, s := range Plan {
-		t = append(t, []string{s.Action, s.Backoff.Interval().String(), s.Backoff.Wait().String()})
+		t = append(t, []string{s.Action.String(), s.Backoff.Interval().String(), s.Backoff.Wait().String()})
 	}
 
 	colourized := table.Colourize(t)

--- a/cmd/plan/pl005/command.go
+++ b/cmd/plan/pl005/command.go
@@ -55,7 +55,7 @@ func mustLong() string {
 	t := [][]string{{"ACTION", "RETRY", "WAIT"}}
 
 	for _, s := range Plan {
-		t = append(t, []string{s.Action, s.Backoff.Interval().String(), s.Backoff.Wait().String()})
+		t = append(t, []string{s.Action.String(), s.Backoff.Interval().String(), s.Backoff.Wait().String()})
 	}
 
 	colourized := table.Colourize(t)

--- a/cmd/plan/pl006/command.go
+++ b/cmd/plan/pl006/command.go
@@ -56,7 +56,7 @@ func mustLong() string {
 	t := [][]string{{"ACTION", "RETRY", "WAIT"}}
 
 	for _, s := range Plan {
-		t = append(t, []string{s.Action, s.Backoff.Interval().String(), s.Backoff.Wait().String()})
+		t = append(t, []string{s.Action.String(), s.Backoff.Interval().String(), s.Backoff.Wait().String()})
 	}
 
 	colourized := table.Colourize(t)

--- a/pkg/plan/executor.go
+++ b/pkg/plan/executor.go
@@ -2,7 +2,6 @@ package plan
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
@@ -112,11 +111,11 @@ func (e *Executor) Validate() error {
 	return nil
 }
 
-func commandForAction(action string, commands []*cobra.Command) (*cobra.Command, error) {
+func commandForAction(action StepAction, commands []*cobra.Command) (*cobra.Command, error) {
 	var cmd *cobra.Command
 
 	cmds := append([]*cobra.Command{}, commands...)
-	acts := strings.Split(action, "/")
+	acts := action.Split()
 
 	for _, a := range acts {
 		for _, c := range cmds {
@@ -129,7 +128,7 @@ func commandForAction(action string, commands []*cobra.Command) (*cobra.Command,
 	}
 
 	if cmd == nil {
-		return nil, microerror.Maskf(commandNotFoundError, action)
+		return nil, microerror.Maskf(commandNotFoundError, string(action))
 	}
 
 	return cmd, nil

--- a/pkg/plan/step.go
+++ b/pkg/plan/step.go
@@ -1,9 +1,21 @@
 package plan
 
+import "strings"
+
 type Step struct {
 	// Action is the action/command name, e.g. ac013.
-	Action string
+	Action StepAction
 	// Backoff is the tolerance within the associated action must be
 	// successfully executed without returning errors.
 	Backoff *Backoff
+}
+
+type StepAction string
+
+func (a StepAction) Split() []string {
+	return strings.Split(string(a), "/")
+}
+
+func (a StepAction) String() string {
+	return strings.ReplaceAll(string(a), "/", " ")
 }


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

I was wondering if this is good or not. I want to let the crowd decide. If you have to ask what changed it might not even be worth it. 😄 

```
$ awscnfm plan pl001 -h
Test plan pl001 launches a basic Tenant Cluster and verifies basic criteria like
the correct number of nodes and pods are running. Plan execution might take up
to 2h47m20s.

ACTION                              RETRY  WAIT
create cluster defaultcontrolplane  2s     10s
verify cluster created              3m0s   30m0s
verify master ready                 2s     10s
create nodepool defaultdataplane    2s     10s
verify worker ready                 3m0s   30m0s
verify master hostnetworkpod        1m0s   15m0s
verify worker hostnetworkpod        2s     10s
verify kiam podandsecret            2s     10s
create kiam awsapicall              2s     10s
verify kiam awsapicall              2s     1m0s
delete kiam awsapicall              2s     10s
delete cluster                      2s     10s
verify cluster deleted              9m0s   1h30m0s

Usage:
  awscnfm plan pl001 [flags]

Flags:
  -h, --help   help for pl001
```