### PR TITLE
remove-cert-exporter-from-hostpodnetworklist

### DIFF
--- a/cmd/action/verify/master/hostnetworkpod/runner.go
+++ b/cmd/action/verify/master/hostnetworkpod/runner.go
@@ -18,7 +18,7 @@ import (
 )
 
 // expectedPods are all host network pods which we expect to run on a master node
-var expectedPods = []string{"aws-node", "calico-node", "cert-exporter", "k8s-api-healthz", "k8s-api-server", "k8s-controller-manager", "k8s-scheduler", "kube-proxy", "node-exporter"}
+var expectedPods = []string{"aws-node", "calico-node", "k8s-api-healthz", "k8s-api-server", "k8s-controller-manager", "k8s-scheduler", "kube-proxy", "node-exporter"}
 
 type runner struct {
 	flag   *flag

--- a/cmd/action/verify/worker/hostnetworkpod/runner.go
+++ b/cmd/action/verify/worker/hostnetworkpod/runner.go
@@ -18,7 +18,7 @@ import (
 )
 
 // expectedPods are all host network pods which we expect to run on a worker node
-var expectedPods = []string{"aws-node", "calico-node", "cert-exporter", "kiam-agent", "kube-proxy", "node-exporter"}
+var expectedPods = []string{"aws-node", "calico-node", "kiam-agent", "kube-proxy", "node-exporter"}
 
 type runner struct {
 	flag   *flag


### PR DESCRIPTION
since the latest version, cert-exporter is no longer running  on host network so removing from the list

related PRs:
https://github.com/giantswarm/k8scloudconfig/pull/839

https://github.com/giantswarm/cert-exporter/pull/67
https://github.com/giantswarm/releases/pull/489/files#diff-0558904bd7b9ba9c4978a85be9be05734a316391b7e871a1a6045c461bcafb7cR74-R79


Also, I will create a PR to  the aws-operator

this means the `master` will fail for versions < 13.0.0 