### PR TITLE
add update specific env var for release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for `AWSCNFM_UPDATE_RELEASEVERSION`.
 - Add action to create network policy test resources.
 - Add action to create curl jobs to test network policy.
 - Add action to verify curl jobs to test network policy.

--- a/cmd/action/update/cluster/major/runner.go
+++ b/cmd/action/update/cluster/major/runner.go
@@ -74,7 +74,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var m *release.Major
 	{
 		c := release.MajorConfig{
-			FromEnv:     env.CreateReleaseVersion(),
+			FromEnv:     env.UpdateReleaseVersion(),
 			FromProject: project.Version(),
 			Releases:    releases,
 		}

--- a/cmd/action/update/cluster/minor/runner.go
+++ b/cmd/action/update/cluster/minor/runner.go
@@ -74,7 +74,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var m *release.Minor
 	{
 		c := release.MinorConfig{
-			FromEnv:     env.CreateReleaseVersion(),
+			FromEnv:     env.UpdateReleaseVersion(),
 			FromProject: project.Version(),
 			Releases:    releases,
 		}

--- a/cmd/action/update/cluster/patch/runner.go
+++ b/cmd/action/update/cluster/patch/runner.go
@@ -74,7 +74,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var p *release.Patch
 	{
 		c := release.PatchConfig{
-			FromEnv:     env.CreateReleaseVersion(),
+			FromEnv:     env.UpdateReleaseVersion(),
 			FromProject: project.Version(),
 			Releases:    releases,
 		}

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -18,6 +18,13 @@ environment variable.
 AWSCNFM_CREATE_RELEASEVERSION
 ```
 
+The release version for updating Tenant Clusters can always be provided via an
+environment variable.
+
+```
+AWSCNFM_UPDATE_RELEASEVERSION
+```
+
 The kube config for the control plane can always be provided via an environment
 variable.
 

--- a/pkg/env/awscnfm_update_releaseversion.go
+++ b/pkg/env/awscnfm_update_releaseversion.go
@@ -1,0 +1,15 @@
+package env
+
+import (
+	"os"
+)
+
+const (
+	EnvVarUpdateReleaseVersion = "AWSCNFM_UPDATE_RELEASEVERSION"
+)
+
+// UpdateReleaseVersion is the release version used to update the Tenant Cluster
+// we want to test for conformity.
+func UpdateReleaseVersion() string {
+	return os.Getenv(EnvVarUpdateReleaseVersion)
+}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

Fixes https://github.com/giantswarm/giantswarm/issues/14546. Since we namespaced the env vars, we can now take a separate env var for the updates. When running conformance tests for updates you would now set two env vars. Successfully tested on `gauss`, though [the test failed in the end due to other reasons](https://github.com/giantswarm/giantswarm/issues/13008#issuecomment-740609550). 

```
export AWSCNFM_CREATE_RELEASEVERSION=v12.5.2
export AWSCNFM_UPDATE_RELEASEVERSION=v12.6.0
```