### PR TITLE
allow plan steps to always be executed

### DIFF
--- a/cmd/plan/pl001/plan.go
+++ b/cmd/plan/pl001/plan.go
@@ -78,11 +78,13 @@ var Plan = []plan.Step{
 		Backoff: plan.NewBackoff(30*time.Second, 4*time.Second),
 	},
 	{
-		Action:  "delete/cluster",
-		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Action:    "delete/cluster",
+		Backoff:   plan.NewBackoff(10*time.Second, 2*time.Second),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 	{
-		Action:  "verify/cluster/deleted",
-		Backoff: plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Action:    "verify/cluster/deleted",
+		Backoff:   plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 }

--- a/cmd/plan/pl002/plan.go
+++ b/cmd/plan/pl002/plan.go
@@ -38,11 +38,13 @@ var Plan = []plan.Step{
 		Backoff: plan.NewBackoff(120*time.Minute, 10*time.Minute),
 	},
 	{
-		Action:  "delete/cluster",
-		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Action:    "delete/cluster",
+		Backoff:   plan.NewBackoff(10*time.Second, 2*time.Second),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 	{
-		Action:  "verify/cluster/deleted",
-		Backoff: plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Action:    "verify/cluster/deleted",
+		Backoff:   plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 }

--- a/cmd/plan/pl003/plan.go
+++ b/cmd/plan/pl003/plan.go
@@ -38,11 +38,13 @@ var Plan = []plan.Step{
 		Backoff: plan.NewBackoff(120*time.Minute, 10*time.Minute),
 	},
 	{
-		Action:  "delete/cluster",
-		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Action:    "delete/cluster",
+		Backoff:   plan.NewBackoff(10*time.Second, 2*time.Second),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 	{
-		Action:  "verify/cluster/deleted",
-		Backoff: plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Action:    "verify/cluster/deleted",
+		Backoff:   plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 }

--- a/cmd/plan/pl004/plan.go
+++ b/cmd/plan/pl004/plan.go
@@ -82,15 +82,18 @@ var Plan = []plan.Step{
 		Backoff: plan.NewBackoff(30*time.Second, 4*time.Second),
 	},
 	{
-		Action:  "delete/cluster",
-		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Action:    "delete/cluster",
+		Backoff:   plan.NewBackoff(10*time.Second, 2*time.Second),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 	{
-		Action:  "delete/networkpool",
-		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Action:    "delete/networkpool",
+		Backoff:   plan.NewBackoff(10*time.Second, 2*time.Second),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 	{
-		Action:  "verify/cluster/deleted",
-		Backoff: plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Action:    "verify/cluster/deleted",
+		Backoff:   plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 }

--- a/cmd/plan/pl005/plan.go
+++ b/cmd/plan/pl005/plan.go
@@ -26,11 +26,13 @@ var Plan = []plan.Step{
 		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
 	},
 	{
-		Action:  "delete/cluster",
-		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Action:    "delete/cluster",
+		Backoff:   plan.NewBackoff(10*time.Second, 2*time.Second),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 	{
-		Action:  "verify/cluster/deleted",
-		Backoff: plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Action:    "verify/cluster/deleted",
+		Backoff:   plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 }

--- a/cmd/plan/pl006/plan.go
+++ b/cmd/plan/pl006/plan.go
@@ -26,11 +26,13 @@ var Plan = []plan.Step{
 		Backoff: plan.NewBackoff(25*time.Minute, 1*time.Minute),
 	},
 	{
-		Action:  "delete/cluster",
-		Backoff: plan.NewBackoff(10*time.Second, 2*time.Second),
+		Action:    "delete/cluster",
+		Backoff:   plan.NewBackoff(10*time.Second, 2*time.Second),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 	{
-		Action:  "verify/cluster/deleted",
-		Backoff: plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Action:    "verify/cluster/deleted",
+		Backoff:   plan.NewBackoff(90*time.Minute, 9*time.Minute),
+		Condition: plan.ConditionAlwaysExecute,
 	},
 }

--- a/pkg/plan/executor.go
+++ b/pkg/plan/executor.go
@@ -64,9 +64,9 @@ func (e *Executor) Execute(ctx context.Context) error {
 	}
 
 	for _, p := range e.plan {
-		e.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("executing action %#q", p.Action))
-
 		o := func() error {
+			e.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("executing action %#q", p.Action))
+
 			cmds, err := commandsForAction("action", e.commands)
 			if err != nil {
 				return microerror.Mask(err)

--- a/pkg/plan/executor.go
+++ b/pkg/plan/executor.go
@@ -53,32 +53,42 @@ func NewExecutor(config ExecutorConfig) (*Executor, error) {
 }
 
 func (e *Executor) Execute(ctx context.Context) error {
-	cmds, err := commandsForAction("action", e.commands)
-	if err != nil {
-		return microerror.Mask(err)
+	var err error
+	var failed bool
+	var cleanup bool
+
+	for _, p := range e.plan {
+		if p.Condition == ConditionAlwaysExecute {
+			cleanup = true
+		}
 	}
 
 	for _, p := range e.plan {
-		c, err := commandForAction(p.Action, cmds)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		// Here we inject the generated cluster ID to each command. That
-		// mechanism ensures that all commands throughout plan exection operate
-		// on the same cluster from cluster creation to cluster deletion. That
-		// implies that all commands must provide the same flag to allow the
-		// propagation of the cluster ID.
-		f := c.LocalNonPersistentFlags()
-		err = f.Set("tenant-cluster", e.tenantCluster)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
 		e.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("executing action %#q", p.Action))
 
 		o := func() error {
-			err := c.RunE(c, nil)
+			cmds, err := commandsForAction("action", e.commands)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			c, err := commandForAction(p.Action, cmds)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			// Here we inject the generated cluster ID to each command. That
+			// mechanism ensures that all commands throughout plan exection operate
+			// on the same cluster from cluster creation to cluster deletion. That
+			// implies that all commands must provide the same flag to allow the
+			// propagation of the cluster ID.
+			f := c.LocalNonPersistentFlags()
+			err = f.Set("tenant-cluster", e.tenantCluster)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			err = c.RunE(c, nil)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -86,9 +96,19 @@ func (e *Executor) Execute(ctx context.Context) error {
 			return nil
 		}
 
-		err = backoff.Retry(o, p.Backoff.Wrapped())
-		if err != nil {
-			return microerror.Mask(err)
+		if cleanup {
+			if !failed || failed && p.Condition == ConditionAlwaysExecute {
+				err = backoff.Retry(o, p.Backoff.Wrapped())
+				if err != nil {
+					failed = true
+					e.logger.LogCtx(ctx, "level", "error", "message", fmt.Sprintf("failed executing action %#q", p.Action))
+				}
+			}
+		} else {
+			err = backoff.Retry(o, p.Backoff.Wrapped())
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 	}
 

--- a/pkg/plan/step.go
+++ b/pkg/plan/step.go
@@ -1,21 +1,13 @@
 package plan
 
-import "strings"
-
 type Step struct {
 	// Action is the action/command name, e.g. ac013.
 	Action StepAction
 	// Backoff is the tolerance within the associated action must be
 	// successfully executed without returning errors.
 	Backoff *Backoff
-}
-
-type StepAction string
-
-func (a StepAction) Split() []string {
-	return strings.Split(string(a), "/")
-}
-
-func (a StepAction) String() string {
-	return strings.ReplaceAll(string(a), "/", " ")
+	// Condition defines when to execute this step of a plan. By default all
+	// steps are executed until an error occurs. This behaviour can be
+	// overwritten to always execute certain steps e.g. for cluster deletion.
+	Condition StepCondition
 }

--- a/pkg/plan/step_action.go
+++ b/pkg/plan/step_action.go
@@ -1,0 +1,13 @@
+package plan
+
+import "strings"
+
+type StepAction string
+
+func (a StepAction) Split() []string {
+	return strings.Split(string(a), "/")
+}
+
+func (a StepAction) String() string {
+	return strings.ReplaceAll(string(a), "/", " ")
+}

--- a/pkg/plan/step_condition.go
+++ b/pkg/plan/step_condition.go
@@ -1,0 +1,7 @@
+package plan
+
+const (
+	ConditionAlwaysExecute = "always-execute"
+)
+
+type StepCondition string


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



### Context 

Fixes https://github.com/giantswarm/giantswarm/issues/14431. You see below how "verify cluster created" is being executed with backoff after perceiving a fake error. After that all actions are skipped except the once configured with `Condition: "always-execute"`. This is contrary to the earlier behaviour of stopping the execution of the plan on error. 


```
$ awscnfm plan pl006
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `create cluster singlecontrolplane`","time":"2020-12-09T15:50:11.761566+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `verify cluster created`","time":"2020-12-09T15:50:11.76164+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `verify cluster created`","time":"2020-12-09T15:50:12.766205+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"error","message":"failed executing action `verify cluster created`","time":"2020-12-09T15:50:12.7664+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `delete cluster`","time":"2020-12-09T15:50:12.76644+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `verify cluster deleted`","time":"2020-12-09T15:50:12.766482+00:00"}
```

I also verified that the plan is executed properly in the ideal scenario, that is, no errors. 

```
$ awscnfm plan pl006
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `create cluster singlecontrolplane`","time":"2020-12-09T15:36:21.724577+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `verify cluster created`","time":"2020-12-09T15:36:21.724652+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `update cluster ha`","time":"2020-12-09T15:36:21.724672+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `verify cluster ha`","time":"2020-12-09T15:36:21.724688+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `delete cluster`","time":"2020-12-09T15:36:21.724703+00:00"}
{"caller":"github.com/giantswarm/micrologger@v0.4.0/activation_logger.go:117","level":"info","message":"executing action `verify cluster deleted`","time":"2020-12-09T15:36:21.724725+00:00"}
```