### PR TITLE
consider cluster id from env when executing plan

### DIFF
--- a/cmd/plan/pl001/error.go
+++ b/cmd/plan/pl001/error.go
@@ -10,12 +10,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var invalidFlagError = &microerror.Error{
-	Kind: "invalidFlagError",
-}
-
-// IsInvalidFlag asserts invalidFlagsError.
-func IsInvalidFlag(err error) bool {
-	return microerror.Cause(err) == invalidFlagError
-}

--- a/cmd/plan/pl001/flag.go
+++ b/cmd/plan/pl001/flag.go
@@ -2,14 +2,23 @@ package pl001
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 )
 
 type flag struct {
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		f.TenantCluster = generate.ID()
+	}
+
 	return nil
 }

--- a/cmd/plan/pl001/runner.go
+++ b/cmd/plan/pl001/runner.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
@@ -44,7 +43,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Logger:   r.logger,
 
 			Plan:          Plan,
-			TenantCluster: generate.ID(),
+			TenantCluster: r.flag.TenantCluster,
 		}
 
 		planExecutor, err = plan.NewExecutor(c)

--- a/cmd/plan/pl002/error.go
+++ b/cmd/plan/pl002/error.go
@@ -10,12 +10,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var invalidFlagError = &microerror.Error{
-	Kind: "invalidFlagError",
-}
-
-// IsInvalidFlag asserts invalidFlagsError.
-func IsInvalidFlag(err error) bool {
-	return microerror.Cause(err) == invalidFlagError
-}

--- a/cmd/plan/pl002/flag.go
+++ b/cmd/plan/pl002/flag.go
@@ -2,14 +2,23 @@ package pl002
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 )
 
 type flag struct {
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		f.TenantCluster = generate.ID()
+	}
+
 	return nil
 }

--- a/cmd/plan/pl002/runner.go
+++ b/cmd/plan/pl002/runner.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
@@ -44,7 +43,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Logger:   r.logger,
 
 			Plan:          Plan,
-			TenantCluster: generate.ID(),
+			TenantCluster: r.flag.TenantCluster,
 		}
 
 		planExecutor, err = plan.NewExecutor(c)

--- a/cmd/plan/pl003/error.go
+++ b/cmd/plan/pl003/error.go
@@ -10,12 +10,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var invalidFlagError = &microerror.Error{
-	Kind: "invalidFlagError",
-}
-
-// IsInvalidFlag asserts invalidFlagsError.
-func IsInvalidFlag(err error) bool {
-	return microerror.Cause(err) == invalidFlagError
-}

--- a/cmd/plan/pl003/flag.go
+++ b/cmd/plan/pl003/flag.go
@@ -2,14 +2,23 @@ package pl003
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 )
 
 type flag struct {
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		f.TenantCluster = generate.ID()
+	}
+
 	return nil
 }

--- a/cmd/plan/pl003/runner.go
+++ b/cmd/plan/pl003/runner.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
@@ -44,7 +43,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Logger:   r.logger,
 
 			Plan:          Plan,
-			TenantCluster: generate.ID(),
+			TenantCluster: r.flag.TenantCluster,
 		}
 
 		planExecutor, err = plan.NewExecutor(c)

--- a/cmd/plan/pl004/error.go
+++ b/cmd/plan/pl004/error.go
@@ -10,12 +10,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var invalidFlagError = &microerror.Error{
-	Kind: "invalidFlagError",
-}
-
-// IsInvalidFlag asserts invalidFlagsError.
-func IsInvalidFlag(err error) bool {
-	return microerror.Cause(err) == invalidFlagError
-}

--- a/cmd/plan/pl004/flag.go
+++ b/cmd/plan/pl004/flag.go
@@ -2,14 +2,23 @@ package pl004
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 )
 
 type flag struct {
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		f.TenantCluster = generate.ID()
+	}
+
 	return nil
 }

--- a/cmd/plan/pl004/runner.go
+++ b/cmd/plan/pl004/runner.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
@@ -44,7 +43,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Logger:   r.logger,
 
 			Plan:          Plan,
-			TenantCluster: generate.ID(),
+			TenantCluster: r.flag.TenantCluster,
 		}
 
 		planExecutor, err = plan.NewExecutor(c)

--- a/cmd/plan/pl005/error.go
+++ b/cmd/plan/pl005/error.go
@@ -10,12 +10,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var invalidFlagError = &microerror.Error{
-	Kind: "invalidFlagError",
-}
-
-// IsInvalidFlag asserts invalidFlagsError.
-func IsInvalidFlag(err error) bool {
-	return microerror.Cause(err) == invalidFlagError
-}

--- a/cmd/plan/pl005/flag.go
+++ b/cmd/plan/pl005/flag.go
@@ -2,14 +2,23 @@ package pl005
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 )
 
 type flag struct {
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		f.TenantCluster = generate.ID()
+	}
+
 	return nil
 }

--- a/cmd/plan/pl005/runner.go
+++ b/cmd/plan/pl005/runner.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
@@ -44,7 +43,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Logger:   r.logger,
 
 			Plan:          Plan,
-			TenantCluster: generate.ID(),
+			TenantCluster: r.flag.TenantCluster,
 		}
 
 		planExecutor, err = plan.NewExecutor(c)

--- a/cmd/plan/pl006/error.go
+++ b/cmd/plan/pl006/error.go
@@ -10,12 +10,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var invalidFlagError = &microerror.Error{
-	Kind: "invalidFlagError",
-}
-
-// IsInvalidFlag asserts invalidFlagsError.
-func IsInvalidFlag(err error) bool {
-	return microerror.Cause(err) == invalidFlagError
-}

--- a/cmd/plan/pl006/flag.go
+++ b/cmd/plan/pl006/flag.go
@@ -2,14 +2,23 @@ package pl006
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/awscnfm/v12/pkg/env"
+	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 )
 
 type flag struct {
+	TenantCluster string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.TenantCluster, "tenant-cluster", "c", env.TenantCluster(), "Tenant Cluster ID to use for this particular action.")
 }
 
 func (f *flag) Validate() error {
+	if f.TenantCluster == "" {
+		f.TenantCluster = generate.ID()
+	}
+
 	return nil
 }

--- a/cmd/plan/pl006/runner.go
+++ b/cmd/plan/pl006/runner.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/awscnfm/v12/pkg/generate"
 	"github.com/giantswarm/awscnfm/v12/pkg/plan"
 )
 
@@ -44,7 +43,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Logger:   r.logger,
 
 			Plan:          Plan,
-			TenantCluster: generate.ID(),
+			TenantCluster: r.flag.TenantCluster,
 		}
 
 		planExecutor, err = plan.NewExecutor(c)

--- a/pkg/plan/executor.go
+++ b/pkg/plan/executor.go
@@ -64,9 +64,9 @@ func (e *Executor) Execute(ctx context.Context) error {
 	}
 
 	for _, p := range e.plan {
-		o := func() error {
-			e.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("executing action %#q", p.Action))
+		e.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("executing action %#q", p.Action))
 
+		o := func() error {
 			cmds, err := commandsForAction("action", e.commands)
 			if err != nil {
 				return microerror.Mask(err)


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

While I was debugging throttling errors in `awscnfm` I noticed that the plan execution against existing clusters did not work. This PR fixes the problem of the env var `AWSCNFM_TENANTCLUSTER` not being respected during consecutive test polan executions. 