### PR TITLE
fix failing kiam action

### DIFF
--- a/cmd/action/create/kiam/awsapicall/job.go
+++ b/cmd/action/create/kiam/awsapicall/job.go
@@ -58,8 +58,7 @@ func jobNetworkPolicy() *networkingv1.NetworkPolicy {
 
 // awsApiCallJob will will spawn a pod which will do simple AWS api call to test Kiam functionality
 func awsApiCallJob(dockerRegistry string, awsRegion string, clusterID string) *batchapiv1.Job {
-	activeDeadlineSeconds := int64(60)
-	backOffLimit := int32(10)
+	backOffLimit := int32(20)
 	completions := int32(1)
 	parallelism := int32(1)
 	name := fmt.Sprintf("%s-kiam-test", project.Name())
@@ -130,7 +129,6 @@ func awsApiCallJob(dockerRegistry string, awsRegion string, clusterID string) *b
 					PriorityClassName: jobPriorityClass,
 				},
 			},
-			ActiveDeadlineSeconds: &activeDeadlineSeconds,
 		},
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context 

During testing I noticed the job to check if kiam is able to call the AWS able was failing. Digging into that it looked like the job was terminating prematurely. We were setting `activeDeadlineSeconds` which prevents all backoffs to retry so the test could never work. With the fixes here the plan execution is fine again.  

See https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup.