### PR TITLE
fix failing awscnfm in china

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Shift organization to `conformance-testing`.
+
 ## [15.0.3] - 2021-07-16
 
 ### Added

--- a/cmd/action/create/nodepool/defaultdataplane/crs.go
+++ b/cmd/action/create/nodepool/defaultdataplane/crs.go
@@ -47,7 +47,7 @@ func (r *runner) newCRs(releases []v1alpha1.Release, host string) (v1alpha2.Node
 			NodesMin:                            1,
 			OnDemandBaseCapacity:                0,
 			OnDemandPercentageAboveBaseCapacity: 0,
-			Owner:                               "giantswarm",
+			Owner:                               key.Organization,
 			ReleaseComponents:                   re.Components(),
 			ReleaseVersion:                      re.Version(),
 			UseAlikeInstanceTypes:               true,

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -19,7 +19,7 @@ const (
 	Credential = "credential-default"
 	// Organization is the Giant Swarm specific organization we create our
 	// conformance test clusters in.
-	Organization = "giantswarm"
+	Organization = "conformance-testing"
 )
 
 const (


### PR DESCRIPTION
Giantswarm Organization is not the expected one for conformance tests, we need to use a seperate one `conformance-testing`. 

## Checklist

- [x] Update changelog in CHANGELOG.md.